### PR TITLE
Get coverage back up to 100%

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,11 @@ RUN chmod -R a+rx /go/bin/traceroute-caller
 
 
 FROM ubuntu:latest
-# Install all the standard packages we need
-RUN apt-get update && apt-get install -y python python-pip make iproute2 coreutils
+# Install all the standard packages we need and then remove the ap-get lists.
+RUN apt-get update && \
+    apt-get install -y python python-pip make iproute2 coreutils && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN ls -l
 RUN mkdir /source
@@ -20,7 +23,7 @@ ADD ./vendor/scamper/ /source
 RUN chmod +x /source/scamper-cvs-20190916/configure
 WORKDIR /source/scamper-cvs-20190916/
 RUN ./configure
-RUN make
+RUN make -j 8
 RUN make install
 RUN ldconfig
 

--- a/connectionwatcher/connectionwatcher_test.go
+++ b/connectionwatcher/connectionwatcher_test.go
@@ -32,6 +32,11 @@ func TestParseIPAndPort(t *testing.T) {
 	if err == nil {
 		log.Println("Should have had an error on bad input")
 	}
+
+	_, _, err = parseIPAndPort("127.0.0.1:1")
+	if err == nil {
+		log.Println("Should have had an error on an ignored IP")
+	}
 }
 
 func TestParseCookie(t *testing.T) {


### PR DESCRIPTION
Fix a dockerfile lint error
Allow scamper to be built in parallel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/24)
<!-- Reviewable:end -->
