### PR TITLE
Cleanup to find bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
 # Vet the code, build the code, and run all the tests.
 - go vet ./...
 - go build ./...
-- go test ./... -v -coverpkg=./... -coverprofile=_coverage.cov
+- go test ./... -v -coverprofile=_coverage.cov
 
 # Build a Docker image to make sure that we can.
 - docker build .

--- a/caller.go
+++ b/caller.go
@@ -79,7 +79,12 @@ func main() {
 		go func() {
 			connCreator, err := connection.NewCreator()
 			rtx.Must(err, "Could not discover local IPs")
-			connListener := connectionlistener.New(&daemon, connCreator, cache, *eventsocketDryRun)
+			esdaemon := daemon
+			esdaemon.DryRun = *eventsocketDryRun
+			if *eventsocketDryRun {
+				cache = ipcache.New(ctx)
+			}
+			connListener := connectionlistener.New(&esdaemon, connCreator, cache)
 			eventsocket.MustRun(ctx, *eventsocket.Filename, connListener)
 			wg.Done()
 		}()

--- a/caller.go
+++ b/caller.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"flag"
+	"sync"
 	"time"
 
 	"github.com/m-lab/traceroute-caller/connection"
@@ -26,7 +27,8 @@ var (
 	scamperCtrlSocket = flag.String("scamper.unixsocket", "/tmp/scamperctrl", "The name of the UNIX-domain socket that the scamper daemon should listen on")
 	outputPath        = flag.String("outputPath", "/var/spool/scamper", "path of output")
 	waitTime          = flag.Duration("waitTime", 5*time.Second, "how long to wait between subsequent listings of open connections")
-	tcpinfoSocket     = flag.String("tcpinfo.socket", "", "The filename of the unix domain socket served by tcpinfo. If this argument is set, then tcpinfo will be used instead of the `ss` command.")
+	eventsocketDryRun = flag.Bool("tcpinfo.eventsocket.dryrun", false, "Whether the eventsocket machinery should be turned on in print-only mode.")
+	poll              = flag.Bool("poll", true, "Whether the polling method should be used to see new connections.")
 
 	ctx, cancel = context.WithCancel(context.Background())
 )
@@ -50,23 +52,37 @@ func main() {
 		OutputPath:       *outputPath,
 		ControlSocket:    *scamperCtrlSocket,
 	}
-	go daemon.MustStart(ctx)
+	go func() {
+		daemon.MustStart(ctx)
+		cancel()
+	}()
 
+	wg := sync.WaitGroup{}
 	cache := ipcache.New(ctx)
-	if *tcpinfoSocket == "" {
-		connPoller := connectionpoller.New(cache)
-		for ctx.Err() == nil {
-			connPoller.TraceClosedConnections(&daemon)
+	if *poll {
+		wg.Add(1)
+		go func() {
+			connPoller := connectionpoller.New(cache)
+			for ctx.Err() == nil {
+				connPoller.TraceClosedConnections(&daemon)
 
-			select {
-			case <-time.After(*waitTime):
-			case <-ctx.Done():
+				select {
+				case <-time.After(*waitTime):
+				case <-ctx.Done():
+				}
 			}
-		}
-	} else {
-		connCreator, err := connection.NewCreator()
-		rtx.Must(err, "Could not discover local IPs")
-		connListener := connectionlistener.New(&daemon, connCreator, cache)
-		eventsocket.MustRun(ctx, *tcpinfoSocket, connListener)
+			wg.Done()
+		}()
 	}
+	if *eventsocket.Filename != "" {
+		wg.Add(1)
+		go func() {
+			connCreator, err := connection.NewCreator()
+			rtx.Must(err, "Could not discover local IPs")
+			connListener := connectionlistener.New(&daemon, connCreator, cache, *eventsocketDryRun)
+			eventsocket.MustRun(ctx, *eventsocket.Filename, connListener)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 }

--- a/caller_test.go
+++ b/caller_test.go
@@ -38,7 +38,8 @@ func TestMainWithConnectionListener(t *testing.T) {
 	rtx.Must(srv.Listen(), "Could not start the empty server")
 
 	*prometheusx.ListenAddress = ":0"
-	*tcpinfoSocket = dir + "/events.sock"
+	*eventsocket.Filename = dir + "/events.sock"
+
 	ctx, cancel = context.WithCancel(context.Background())
 	go srv.Serve(ctx)
 	go func() {

--- a/caller_test.go
+++ b/caller_test.go
@@ -39,6 +39,7 @@ func TestMainWithConnectionListener(t *testing.T) {
 
 	*prometheusx.ListenAddress = ":0"
 	*eventsocket.Filename = dir + "/events.sock"
+	*eventsocketDryRun = true
 
 	ctx, cancel = context.WithCancel(context.Background())
 	go srv.Serve(ctx)

--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -92,6 +92,28 @@ func TestSrcDestSwap(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "All local",
+			sockid: inetdiag.SockID{
+				DstIP:  "1.2.3.4",
+				DPort:  17,
+				SrcIP:  "1.2.3.4",
+				SPort:  11,
+				Cookie: 0xc,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Bad IPs",
+			sockid: inetdiag.SockID{
+				DstIP:  "1.3.4",
+				DPort:  17,
+				SrcIP:  "2.3.4",
+				SPort:  11,
+				Cookie: 0xc,
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/connectionlistener/connectionlistener.go
+++ b/connectionlistener/connectionlistener.go
@@ -55,7 +55,7 @@ func (cl *connectionListener) Close(ctx context.Context, timestamp time.Time, uu
 
 // New returns an eventsocket.Handler that will call the passed-in scamper
 // daemon on every closed connection.
-func New(tracer scamper.Tracer, creator connection.Creator, cache *ipcache.RecentIPCache, dryRun bool) eventsocket.Handler {
+func New(tracer scamper.Tracer, creator connection.Creator, cache *ipcache.RecentIPCache) eventsocket.Handler {
 	return &connectionListener{
 		conns:   make(map[string]connection.Connection),
 		tracer:  tracer,

--- a/connectionlistener/connectionlistener.go
+++ b/connectionlistener/connectionlistener.go
@@ -1,6 +1,7 @@
 package connectionlistener
 
 import (
+	"context"
 	"log"
 	"sync"
 	"time"
@@ -23,7 +24,7 @@ type connectionListener struct {
 	creator connection.Creator
 }
 
-func (cl *connectionListener) Open(timestamp time.Time, uuid string, id *inetdiag.SockID) {
+func (cl *connectionListener) Open(ctx context.Context, timestamp time.Time, uuid string, id *inetdiag.SockID) {
 	cl.mutex.Lock()
 	defer cl.mutex.Unlock()
 	if id != nil {
@@ -36,7 +37,7 @@ func (cl *connectionListener) Open(timestamp time.Time, uuid string, id *inetdia
 	}
 }
 
-func (cl *connectionListener) Close(timestamp time.Time, uuid string) {
+func (cl *connectionListener) Close(ctx context.Context, timestamp time.Time, uuid string) {
 	cl.mutex.Lock()
 	conn, ok := cl.conns[uuid]
 	if ok {
@@ -54,7 +55,7 @@ func (cl *connectionListener) Close(timestamp time.Time, uuid string) {
 
 // New returns an eventsocket.Handler that will call the passed-in scamper
 // daemon on every closed connection.
-func New(tracer scamper.Tracer, creator connection.Creator, cache *ipcache.RecentIPCache) eventsocket.Handler {
+func New(tracer scamper.Tracer, creator connection.Creator, cache *ipcache.RecentIPCache, dryRun bool) eventsocket.Handler {
 	return &connectionListener{
 		conns:   make(map[string]connection.Connection),
 		tracer:  tracer,

--- a/connectionlistener/connectionlistener_test.go
+++ b/connectionlistener/connectionlistener_test.go
@@ -61,7 +61,7 @@ func TestListener(t *testing.T) {
 
 	localIP := net.ParseIP("10.0.0.1")
 	creator := connection.NewFakeCreator([]*net.IP{&localIP})
-	cl := connectionlistener.New(ft, creator, cache, false)
+	cl := connectionlistener.New(ft, creator, cache)
 
 	// Connect the connectionlistener to the server
 	go eventsocket.MustRun(ctx, dir+"/tcpevents.sock", cl)

--- a/connectionlistener/connectionlistener_test.go
+++ b/connectionlistener/connectionlistener_test.go
@@ -61,7 +61,7 @@ func TestListener(t *testing.T) {
 
 	localIP := net.ParseIP("10.0.0.1")
 	creator := connection.NewFakeCreator([]*net.IP{&localIP})
-	cl := connectionlistener.New(ft, creator, cache)
+	cl := connectionlistener.New(ft, creator, cache, false)
 
 	// Connect the connectionlistener to the server
 	go eventsocket.MustRun(ctx, dir+"/tcpevents.sock", cl)

--- a/connectionpoller/connectionpoller_test.go
+++ b/connectionpoller/connectionpoller_test.go
@@ -32,6 +32,11 @@ func TestParseIPAndPort(t *testing.T) {
 		log.Println("Should have had an error on a bad ip")
 	}
 
+	_, _, err = parseIPAndPort("1.2.3.4:notaport")
+	if err == nil {
+		log.Println("Should have had an error on a bad port")
+	}
+
 	_, _, err = parseIPAndPort("not an address at all")
 	if err == nil {
 		log.Println("Should have had an error on bad input")
@@ -94,10 +99,13 @@ func TestGetConnectionsWithFakeSS(t *testing.T) {
 	rtx.Must(err, "Could not create tempdir")
 	defer os.RemoveAll(tmpdir)
 
-	// Print out two connections, one of which has no cookie.
+	// Print out five connections, one of which has no cookie, another of which is not a tcp connection, two more with bad local or remote IPs, and one good one.
 	fakeSS := `#!/bin/bash
-	echo 'tcp   ESTAB      0      0         [2620:0:1003:416:a0ad:fd1a:62f:c862]:58790                       [2607:f8b0:400d:c0d::81]:5034                  timer:(keepalive,5.980ms,0) ino:6355539 sk:10f3d <->'
 	echo 'tcp   ESTAB      0      0         [2620:0:1003:416:a0ad:fd1a:62f:c862]:58791                       [2607:f8b0:400d:c0d::81]:5034                  timer:(keepalive,5.980ms,0) ino:6355540 <->'
+	echo 'nottcp   ESTAB      0      0         [2620:0:1003:416:a0ad:fd1a:62f:c862]:58792                       [2607:f8b0:400d:c0d::81]:5034                  timer:(keepalive,5.980ms,0) ino:6355539 sk:10f3d <->'
+	echo 'tcp   ESTAB      0      0         [2620:0:1003:416:a0ad:fd1a:62f:c862]:badport                       [2607:f8b0:400d:c0d::81]:5034                  timer:(keepalive,5.980ms,0) ino:6355539 sk:10f3d <->'
+	echo 'tcp   ESTAB      0      0         [2620:0:1003:416:a0ad:fd1a:62f:c862]:58790                       [badip]:5034                  timer:(keepalive,5.980ms,0) ino:6355539 sk:10f3d <->'
+	echo 'tcp   ESTAB      0      0         [2620:0:1003:416:a0ad:fd1a:62f:c862]:58790                       [2607:f8b0:400d:c0d::81]:5034                  timer:(keepalive,5.980ms,0) ino:6355539 sk:10f3d <->'
 	`
 	rtx.Must(ioutil.WriteFile(tmpdir+"/ss", []byte(fakeSS), 0777), "Could not create fake ss")
 

--- a/connectionpoller/connectionpoller_test.go
+++ b/connectionpoller/connectionpoller_test.go
@@ -148,11 +148,9 @@ func TestConnectionPollerConstruction(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cache := ipcache.New(ctx)
-	connPoller := &connectionPoller{
-		finder:         &testFinder{},
-		recentIPCache:  cache,
-		connectionPool: make(map[connection.Connection]struct{}),
-	}
+	connPoller := New(cache).(*connectionPoller)
+	connPoller.finder = &testFinder{}
+	connPoller.connectionPool = make(map[connection.Connection]struct{})
 	conn1 := connection.Connection{
 		RemoteIP:   "1.1.1.2",
 		RemotePort: 5034,

--- a/scamper/scamper.go
+++ b/scamper/scamper.go
@@ -201,6 +201,9 @@ func (d *Daemon) trace(conn connection.Connection, t time.Time) string {
 	_, err := buff.WriteString(GetMetaline(conn, 0, ""))
 	rtx.PanicOnError(err, "Could not write to buffer")
 
+	log.Printf(
+		"Running: echo \"tracelb -P icmp-echo -q 3 -O ptr %s\" | %s -i- -o- -U %s | %s > %s\n",
+		conn.RemoteIP, d.AttachBinary, d.ControlSocket, d.Warts2JSONBinary, filename)
 	cmd := pipe.Line(
 		pipe.Println("tracelb -P icmp-echo -q 3 -O ptr ", conn.RemoteIP),
 		pipe.Exec(d.AttachBinary, "-i-", "-o-", "-U", d.ControlSocket),


### PR DESCRIPTION
Standardize flags, parse IPs in a more cautious manner, don't run local-local traceroutes, add a dryRun flag.

Part of the efforts due to https://github.com/m-lab/traceroute-caller/issues/38

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/39)
<!-- Reviewable:end -->
