### PR TITLE
Now tests non-stalling of races.

### DIFF
--- a/ipcache/ipcache.go
+++ b/ipcache/ipcache.go
@@ -73,6 +73,8 @@ func (rc *RecentIPCache) Trace(conn connection.Connection) string {
 // primary use of this is for testing, to ensure that something was put into or
 // removed from the cache.
 func (rc *RecentIPCache) GetCacheLength() int {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
 	return len(rc.cache)
 }
 

--- a/ipcache/ipcache_test.go
+++ b/ipcache/ipcache_test.go
@@ -3,6 +3,7 @@ package ipcache_test
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -100,7 +101,7 @@ type pausingTracer struct {
 }
 
 func (pt *pausingTracer) Trace(conn connection.Connection, t time.Time) string {
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(time.Duration(rand.Intn(1000000)))
 	if conn.RemoteIP == pt.traceToBlock {
 		<-pt.ctx.Done()
 	}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/45)
<!-- Reviewable:end -->
