### PR TITLE
go test ./... -race fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
 # Vet the code, build the code, and run all the tests.
 - go vet ./...
 - go build ./...
-- go test ./... -v -coverprofile=_coverage.cov
+- go test ./... -v -coverprofile=_coverage.cov -race
 
 # Build a Docker image to make sure that we can.
 - docker build .

--- a/caller.go
+++ b/caller.go
@@ -64,8 +64,8 @@ func main() {
 	cache := ipcache.New(ctx, &daemon, *ipcache.IPCacheTimeout, *ipcache.IPCacheUpdatePeriod)
 	if *poll {
 		wg.Add(1)
-		go func() {
-			connPoller := connectionpoller.New(cache)
+		go func(c *ipcache.RecentIPCache) {
+			connPoller := connectionpoller.New(c)
 			for ctx.Err() == nil {
 				connPoller.TraceClosedConnections()
 
@@ -75,7 +75,7 @@ func main() {
 				}
 			}
 			wg.Done()
-		}()
+		}(cache)
 	}
 	if *eventsocket.Filename != "" {
 		wg.Add(1)

--- a/connectionlistener/connectionlistener_test.go
+++ b/connectionlistener/connectionlistener_test.go
@@ -24,11 +24,14 @@ import (
 )
 
 type fakeTracer struct {
-	ips []string
-	wg  sync.WaitGroup
+	ips   []string
+	mutex sync.Mutex
+	wg    sync.WaitGroup
 }
 
 func (ft *fakeTracer) Trace(conn connection.Connection, t time.Time) string {
+	ft.mutex.Lock() // Must have a lock to avoid race conditions around the append.
+	defer ft.mutex.Unlock()
 	log.Println("Tracing", conn)
 	ft.ips = append(ft.ips, conn.RemoteIP)
 	ft.wg.Done()

--- a/connectionlistener/connectionlistener_test.go
+++ b/connectionlistener/connectionlistener_test.go
@@ -66,6 +66,7 @@ func TestListener(t *testing.T) {
 	localIP := net.ParseIP("10.0.0.1")
 	creator := connection.NewFakeCreator([]*net.IP{&localIP})
 	cl := connectionlistener.New(creator, cache)
+	cl.Open(ctx, time.Now(), "", nil) // Test that nil pointer to Open does not cause a crash.
 
 	// Connect the connectionlistener to the server
 	go eventsocket.MustRun(ctx, dir+"/tcpevents.sock", cl)


### PR DESCRIPTION
Also updates travis to use `go test ./... -race`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/46)
<!-- Reviewable:end -->
