### PR TITLE
Fix test race condition.

### DIFF
--- a/caller_test.go
+++ b/caller_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"io/ioutil"
+	"log"
+	"os"
 	"testing"
 	"time"
 
@@ -21,6 +23,7 @@ func TestMetrics(t *testing.T) {
 func TestMain(t *testing.T) {
 	dir, err := ioutil.TempDir("", "TestMain")
 	rtx.Must(err, "Could not create temp dir")
+	defer os.RemoveAll(dir)
 
 	// Verify that main doesn't crash, and that it does exit when the context is canceled.
 	// TODO: verify more in this test.
@@ -28,6 +31,7 @@ func TestMain(t *testing.T) {
 	*scamperCtrlSocket = dir + "/scamper.sock"
 	*waitTime = time.Nanosecond // Run through the loop a few times.
 	*outputPath = dir
+	*poll = true
 	tracerType.Value = "scamper"
 	ctx, cancel = context.WithCancel(context.Background())
 	go func() {
@@ -40,6 +44,7 @@ func TestMain(t *testing.T) {
 func TestMainWithConnectionListener(t *testing.T) {
 	dir, err := ioutil.TempDir("", "TestMainWithConnectionListener")
 	rtx.Must(err, "Could not create temp dir")
+	defer os.RemoveAll(dir)
 	srv := eventsocket.New(dir + "/events.sock")
 	rtx.Must(srv.Listen(), "Could not start the empty server")
 
@@ -47,6 +52,7 @@ func TestMainWithConnectionListener(t *testing.T) {
 	*scamperCtrlSocket = dir + "/scamper.sock"
 	*eventsocket.Filename = dir + "/events.sock"
 	*outputPath = dir
+	*poll = false
 	tracerType.Value = "paris-traceroute"
 
 	ctx, cancel = context.WithCancel(context.Background())
@@ -55,5 +61,27 @@ func TestMainWithConnectionListener(t *testing.T) {
 		time.Sleep(1 * time.Second)
 		cancel()
 	}()
+	main()
+}
+
+func TestMainWithBadArgs(t *testing.T) {
+	tracerType.Value = "paris-traceroute"
+	*eventsocket.Filename = ""
+	*outputPath = "/tmp/"
+	*poll = false
+
+	logFatal = func(_ ...interface{}) {
+		panic("testpanic")
+	}
+	defer func() {
+		logFatal = log.Fatal
+	}()
+	defer func() {
+		r := recover()
+		if r != "testpanic" {
+			t.Error("Should have had a panic called testpanic, not", r)
+		}
+	}()
+
 	main()
 }


### PR DESCRIPTION
Successfully passed with `go test ./... -race -count=100`

Fixes #57

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/58)
<!-- Reviewable:end -->
