### PR TITLE
Add scamper-standalone as a backup option for scamper-daemon

### DIFF
--- a/caller.go
+++ b/caller.go
@@ -34,7 +34,7 @@ var (
 	waitTime          = flag.Duration("waitTime", 5*time.Second, "how long to wait between subsequent listings of open connections")
 	poll              = flag.Bool("poll", true, "Whether the polling method should be used to see new connections.")
 	tracerType        = flagx.Enum{
-		Options: []string{"paris-traceroute", "scamper", "scamper-daemon", "scamper-daemon-with-paris-backup"},
+		Options: []string{"paris-traceroute", "scamper", "scamper-daemon", "scamper-daemon-with-paris-backup", "scamper-daemon-with-scamper-backup"},
 		Value:   "scamper",
 	}
 
@@ -95,6 +95,16 @@ func main() {
 			scamperDaemon.MustStart(ctx)
 			// When the scamper daemon dies, cancel main() and exit.
 			cancel()
+			wg.Done()
+		}()
+	// These are hacks - the scamper daemon should not fail at all.
+	case "scamper-daemon-with-scamper-backup":
+		cache = ipcache.New(ctx, scamperDaemon, *ipcache.IPCacheTimeout, *ipcache.IPCacheUpdatePeriod)
+		wg.Add(1)
+		go func() {
+			scamperDaemon.MustStart(ctx)
+			// When the scamper daemon dies, switch to scamper
+			cache.UpdateTracer(scamper)
 			wg.Done()
 		}()
 	case "scamper-daemon-with-paris-backup":

--- a/caller_test.go
+++ b/caller_test.go
@@ -86,6 +86,30 @@ func TestMainWithConnectionListener(t *testing.T) {
 	main()
 }
 
+func TestMainWithBackupScamper(t *testing.T) {
+	dir, err := ioutil.TempDir("", "TestMainWithBackupScamper")
+	rtx.Must(err, "Could not create temp dir")
+	defer os.RemoveAll(dir)
+	srv := eventsocket.New(dir + "/events.sock")
+	rtx.Must(srv.Listen(), "Could not start the empty server")
+
+	*prometheusx.ListenAddress = ":0"
+	*eventsocket.Filename = dir + "/events.sock"
+	*outputPath = dir
+	*poll = false
+	*scamperCtrlSocket = dir + "/scamper.sock"
+	*scamperBin = "false"
+	tracerType.Value = "scamper-daemon-with-scamper-backup"
+
+	ctx, cancel = context.WithCancel(context.Background())
+	go srv.Serve(ctx)
+	go func() {
+		time.Sleep(1 * time.Second)
+		cancel()
+	}()
+	main()
+}
+
 func TestMainWithBackupPT(t *testing.T) {
 	dir, err := ioutil.TempDir("", "TestMainWithBackupPT")
 	rtx.Must(err, "Could not create temp dir")

--- a/tracer/scamper.go
+++ b/tracer/scamper.go
@@ -134,6 +134,8 @@ type ScamperDaemon struct {
 // We expect this function to be mostly used as a goroutine:
 //    go d.MustStart(ctx)
 func (d *ScamperDaemon) MustStart(ctx context.Context) {
+	scamperDaemonRunning.Set(1)
+	defer scamperDaemonRunning.Set(0)
 	derivedCtx, derivedCancel := context.WithCancel(ctx)
 	defer derivedCancel()
 	if _, err := os.Stat(d.ControlSocket); !os.IsNotExist(err) {

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -49,6 +49,12 @@ var (
 		},
 		[]string{"type", "error"},
 	)
+	scamperDaemonRunning = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "traces_scamper_daemon_running",
+			Help: "Whether the scamper daemon is running or not.",
+		},
+	)
 
 	// hostname of the current machine. Only call os.Hostname once, because the
 	// result should never change.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/64)
<!-- Reviewable:end -->
