### PR TITLE
Do not add an extra double quotes to JSON string values

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -19,7 +19,7 @@ type HopProbe struct {
 }
 
 type HopLink struct {
-	HopDstIP string     `json:"hop_dst_ip,string"`
+	HopDstIP string     `json:"hop_dst_ip"`
 	TTL      int64      `json:"ttl,int64"`
 	Probes   []HopProbe `json:"probes"`
 }


### PR DESCRIPTION
I've verified that this change works as expected in the sandbox environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/85)
<!-- Reviewable:end -->
