### PR TITLE
Update Travis CI configuration in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,7 @@ script:
 - go test ./... -race
 - go test ./... -v -coverprofile=_coverage.cov
 
-# Build a Docker image to make sure that we can.
-- docker build .
-
+after_success:
 # Coveralls
 # Upload coverage information for unit tests.
 - $HOME/gopath/bin/goveralls -coverprofile=_coverage.cov -service=travis-ci


### PR DESCRIPTION
This commit makes two changes:

1. It removes "docker build ." because Travis builds are failing
   due to Docker Hub rate limits and we don't need the continer
   image that Travis builds anyway.

2. It moves uploading of coverage information to the "after_success"
   stage so that a failure in uploading coverage doesn't cause Travis
   to fail.

Tested via a push to my feature branch, triggering a build.
Both Docker Hub and Travis CI passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/90)
<!-- Reviewable:end -->
