### PR TITLE
Add comments to json.go

### DIFF
--- a/parser/json.go
+++ b/parser/json.go
@@ -13,37 +13,49 @@ import (
 )
 
 // Parse Scamper JSON filename like
-// The format of JSON can be found at https://www.caida.org/tools/measurement/scamper/.
+// The format of JSON can be found at
+// https://www.caida.org/tools/measurement/scamper/.
+// NB: It is not clear where at that URL the format can be found.
+// The structs here may just be derived from the actual scamper json files.
+// scamper-cvs-20191102 trace/scamper_trace.h contains C structs that
+// may be helpful for understanding this, though the structures are different
+// from the JSON structure.
 
+// TS contains a unix epoch timestamp.
 type TS struct {
 	Sec  int64 `json:"sec"`
 	Usec int64 `json:"usec"`
 }
 
+// Reply describes a single reply message.
 type Reply struct {
 	Rx         TS      `json:"rx"`
-	Ttl        int     `json:"ttl"`
-	Rtt        float64 `json:"rtt"`
+	TTL        int     `json:"ttl"`
+	RTT        float64 `json:"rtt"`
 	Icmp_type  int     `json:"icmp_type"`
 	Icmp_code  int     `json:"icmp_code"`
 	Icmp_q_tos int     `json:"icmp_q_tos"`
 	Icmp_q_ttl int     `json:"icmp_q_ttl"`
 }
 
+// Probe describes a single probe message, and all the associated replies.
 type Probe struct {
 	Tx      TS      `json:"tx"`
 	Replyc  int     `json:"replyc"`
 	Ttl     int64   `json:"ttl"`
 	Attempt int     `json:"attempt"`
 	Flowid  int64   `json:"flowid"`
-	Replies []Reply `json:"replies"`
+	Replies []Reply `json:"replies"` // There is usually just a single reply
 }
 
+// ScamperLink describes a single step in the trace.  The probes within a
+// ScamperLink appear to have the same value of TTL, but different flow_ids.
 type ScamperLink struct {
 	Addr   string  `json:"addr"`
 	Probes []Probe `json:"probes"`
 }
 
+// ScamperNode describes a layer of links.
 type ScamperNode struct {
 	Addr  string          `json:"addr"`
 	Name  string          `json:"name"`
@@ -58,6 +70,7 @@ type ScamperNode struct {
 // The third line is defined in TracelbLine
 // The fourth line is defined in CyclestopLine
 
+// Metadata contains the UUID and other metadata provided by the traceroute-caller code.
 type Metadata struct {
 	UUID                    string `json:"UUID" binding:"required"`
 	TracerouteCallerVersion string `json:"TracerouteCallerVersion"`
@@ -65,22 +78,26 @@ type Metadata struct {
 	CachedUUID              string `json:"CachedUUID"`
 }
 
+// CyclestartLine contains the information about the scamper "cyclestart"
 type CyclestartLine struct {
-	Type       string  `json:"type"`
-	List_name  string  `json:"list_name"`
-	ID         float64 `json:"id"`
+	Type       string  `json:"type"`      // "cycle-start"
+	List_name  string  `json:"list_name"` // e.g. "/tmp/scamperctrl:58"
+	ID         float64 `json:"id"`        // e.g. 1 - seems to be an integer?
 	Hostname   string  `json:"hostname"`
-	Start_time float64 `json:"start_time"`
+	Start_time float64 `json:"start_time"` // This is a unix epoch time.
 }
 
+// TracelbLine contains the actual scamper trace details.
+// Not clear why so many fields are floats.  Fields in scamper code are uint16_t and uint8_t
 type TracelbLine struct {
-	Type         string        `json:"type"`
-	Version      string        `json:"version"`
-	Userid       float64       `json:"userid"`
-	Method       string        `json:"method"`
-	Src          string        `json:"src"`
-	Dst          string        `json:"dst"`
-	Start        TS            `json:"start"`
+	Type    string  `json:"type"`
+	Version string  `json:"version"`
+	Userid  float64 `json:"userid"`
+	Method  string  `json:"method"`
+	Src     string  `json:"src"`
+	Dst     string  `json:"dst"`
+	Start   TS      `json:"start"`
+	// NOTE: None of these seem to be actual floats - all ints.
 	Probe_size   float64       `json:"probe_size"`
 	Firsthop     float64       `json:"firsthop"`
 	Attempts     float64       `json:"attempts"`
@@ -96,14 +113,18 @@ type TracelbLine struct {
 	Nodes        []ScamperNode `json:"nodes"`
 }
 
+// CyclestopLine contains the ending details from the scamper tool.  ID,
+// List_name, hostname seem to match CyclestartLine
 type CyclestopLine struct {
-	Type      string  `json:"type"`
+	Type      string  `json:"type"` // "cycle-stop"
 	List_name string  `json:"list_name"`
 	ID        float64 `json:"id"`
 	Hostname  string  `json:"hostname"`
-	Stop_time float64 `json:"stop_time"`
+	Stop_time float64 `json:"stop_time"` // This is a unix epoch time.
 }
 
+// ParseRaw parses JSONL files containing the four JSON lines described above,
+// into the TRC3.0 schema structs.
 func ParseRaw(data []byte, connTime time.Time) (schema.PTTestRaw, error) {
 	var uuid, version string
 	var resultFromCache bool
@@ -178,7 +199,7 @@ func ParseRaw(data []byte, connTime time.Time) (schema.PTTestRaw, error) {
 			for _, oneProbe := range oneLink.Probes {
 				var rtt []float64
 				for _, oneReply := range oneProbe.Replies {
-					rtt = append(rtt, oneReply.Rtt)
+					rtt = append(rtt, oneReply.RTT)
 				}
 				probes = append(probes, schema.HopProbe{Flowid: int64(oneProbe.Flowid), Rtt: rtt})
 				ttl = int64(oneProbe.Ttl)
@@ -216,6 +237,7 @@ func ParseRaw(data []byte, connTime time.Time) (schema.PTTestRaw, error) {
 }
 
 // ParseJSON the raw jsonl test file into schema.PTTest.
+// NB: This is NOT the scamper tool format.
 func ParseJSON(testName string, rawContent []byte) (schema.PTTestRaw, error) {
 	// Get the logtime
 	logTime, err := GetLogtime(PTFileName{Name: filepath.Base(testName)})


### PR DESCRIPTION
I haven't figured out how to suppress warnings from golint.  Various urls suggest that //nolint or // nolint should work, but they do not.

We may actually be able to change the names to use camelCase, but for now let's leave them as is, and tolerate the warnings until we can figure out how to suppress them.

There are no code changes aside from renaming RTT and TTL, so go vet and travis tests are sufficient to ensure correctness.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/94)
<!-- Reviewable:end -->
