### PR TITLE
Clean up Go source code

### DIFF
--- a/caller.go
+++ b/caller.go
@@ -1,4 +1,22 @@
-// Package main provides the traceroute-caller.
+// traceroute-caller is a wrapper around the `paris-traceroute` and
+// `scamper` commands and can be invoked in two different poll and
+// listen modes:
+//
+//   - Poll mode uses the `connectionpoller` package to get a complete list
+//     of all connections by executing `/bin/ss -e -n` every 5 seconds
+//     and running a traceroute on all closed connections.  This mode is
+//     mostly for local test and debugging purposes as it doesn't require
+//     any services such as `tcp-info` or `uuid-annotator`.
+//
+//   - Listen mode uses the `tcp-info/eventsocket` package to listen for
+//     open and close connection events, and runs a traceroute measurement
+//     on closed connections.
+//
+// traceroute-caller on M-Lab servers always runs in the listen mode.
+// To see all available flags:
+//
+//   $ go build
+//   $ ./traceroute-caller --help
 package main
 
 import (
@@ -47,9 +65,6 @@ func init() {
 	flag.Var(&tracerType, "tracetool", "Choose whether paris-traceroute or scamper should be used.")
 }
 
-// Sample cmd:
-// go build
-// ./traceroute-caller --outputPath scamper_output
 func main() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/m-lab/uuid v0.0.0-20191115203855-549727171666
 	github.com/m-lab/uuid-annotator v0.4.4
 	github.com/prometheus/client_golang v1.10.0
+	golang.org/x/mod v0.4.0 // indirect
+	golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c // indirect
 	gopkg.in/m-lab/pipe.v3 v3.0.0-20180108231244-604e84f43ee0
-	mvdan.cc/gofumpt v0.1.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -344,7 +344,6 @@ github.com/prometheus/prometheus v2.5.0+incompatible/go.mod h1:oAIUtOny2rjMX0OWN
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rogpeppe/go-internal v1.6.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
@@ -434,7 +433,6 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKG
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
-golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0 h1:8pl+sMODzuvGJkmj2W4kZihvVb5mKm8pB/X44PIQHv8=
@@ -466,7 +464,6 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200421231249-e086a090c8fd/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -577,13 +574,11 @@ golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjs
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200409170454-77362c5149f0/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.0.0-20200422205258-72e4a01eba43 h1:Lcsc5ErIWemp8qAbYffG5vPrqjJ0zk82RTFGifeS1Pc=
 golang.org/x/tools v0.0.0-20200422205258-72e4a01eba43/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c h1:dS09fXwOFF9cXBnIzZexIuUBj95U1NyQjkEhkgidDow=
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -691,8 +686,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3U=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-mvdan.cc/gofumpt v0.1.1 h1:bi/1aS/5W00E2ny5q65w9SnKpWEF/UIOqDYBILpo9rA=
-mvdan.cc/gofumpt v0.1.1/go.mod h1:yXG1r1WqZVKWbVRtBWKWX9+CxGYfA51nSomhM0woR48=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/parser/json.go
+++ b/parser/json.go
@@ -29,20 +29,20 @@ type TS struct {
 
 // Reply describes a single reply message.
 type Reply struct {
-	Rx         TS      `json:"rx"`
-	TTL        int     `json:"ttl"`
-	RTT        float64 `json:"rtt"`
-	Icmp_type  int     `json:"icmp_type"`
-	Icmp_code  int     `json:"icmp_code"`
-	Icmp_q_tos int     `json:"icmp_q_tos"`
-	Icmp_q_ttl int     `json:"icmp_q_ttl"`
+	Rx       TS      `json:"rx"`
+	TTL      int     `json:"ttl"`
+	RTT      float64 `json:"rtt"`
+	IcmpType int     `json:"icmp_type"`
+	IcmpCode int     `json:"icmp_code"`
+	IcmpQTos int     `json:"icmp_q_tos"`
+	IcmpQTTL int     `json:"icmp_q_ttl"`
 }
 
 // Probe describes a single probe message, and all the associated replies.
 type Probe struct {
 	Tx      TS      `json:"tx"`
 	Replyc  int     `json:"replyc"`
-	Ttl     int64   `json:"ttl"`
+	TTL     int64   `json:"ttl"`
 	Attempt int     `json:"attempt"`
 	Flowid  int64   `json:"flowid"`
 	Replies []Reply `json:"replies"` // There is usually just a single reply
@@ -59,7 +59,7 @@ type ScamperLink struct {
 type ScamperNode struct {
 	Addr  string          `json:"addr"`
 	Name  string          `json:"name"`
-	Q_ttl int             `json:"q_ttl"`
+	QTTL  int             `json:"q_ttl"`
 	Linkc int64           `json:"linkc"`
 	Links [][]ScamperLink `json:"links"`
 }
@@ -80,11 +80,11 @@ type Metadata struct {
 
 // CyclestartLine contains the information about the scamper "cyclestart"
 type CyclestartLine struct {
-	Type       string  `json:"type"`      // "cycle-start"
-	List_name  string  `json:"list_name"` // e.g. "/tmp/scamperctrl:58"
-	ID         float64 `json:"id"`        // e.g. 1 - seems to be an integer?
-	Hostname   string  `json:"hostname"`
-	Start_time float64 `json:"start_time"` // This is a unix epoch time.
+	Type      string  `json:"type"`      // "cycle-start"
+	ListName  string  `json:"list_name"` // e.g. "/tmp/scamperctrl:58"
+	ID        float64 `json:"id"`        // e.g. 1 - seems to be an integer?
+	Hostname  string  `json:"hostname"`
+	StartTime float64 `json:"start_time"` // This is a unix epoch time.
 }
 
 // TracelbLine contains the actual scamper trace details.
@@ -98,29 +98,29 @@ type TracelbLine struct {
 	Dst     string  `json:"dst"`
 	Start   TS      `json:"start"`
 	// NOTE: None of these seem to be actual floats - all ints.
-	Probe_size   float64       `json:"probe_size"`
-	Firsthop     float64       `json:"firsthop"`
-	Attempts     float64       `json:"attempts"`
-	Confidence   float64       `json:"confidence"`
-	Tos          float64       `json:"tos"`
-	Gaplint      float64       `json:"gaplint"`
-	Wait_timeout float64       `json:"wait_timeout"`
-	Wait_probe   float64       `json:"wait_probe"`
-	Probec       float64       `json:"probec"`
-	Probec_max   float64       `json:"probec_max"`
-	Nodec        float64       `json:"nodec"`
-	Linkc        float64       `json:"linkc"`
-	Nodes        []ScamperNode `json:"nodes"`
+	ProbeSize   float64       `json:"probe_size"`
+	Firsthop    float64       `json:"firsthop"`
+	Attempts    float64       `json:"attempts"`
+	Confidence  float64       `json:"confidence"`
+	Tos         float64       `json:"tos"`
+	Gaplint     float64       `json:"gaplint"`
+	WaitTimeout float64       `json:"wait_timeout"`
+	WaitProbe   float64       `json:"wait_probe"`
+	Probec      float64       `json:"probec"`
+	ProbecMax   float64       `json:"probec_max"`
+	Nodec       float64       `json:"nodec"`
+	Linkc       float64       `json:"linkc"`
+	Nodes       []ScamperNode `json:"nodes"`
 }
 
 // CyclestopLine contains the ending details from the scamper tool.  ID,
-// List_name, hostname seem to match CyclestartLine
+// ListName, hostname seem to match CyclestartLine
 type CyclestopLine struct {
-	Type      string  `json:"type"` // "cycle-stop"
-	List_name string  `json:"list_name"`
-	ID        float64 `json:"id"`
-	Hostname  string  `json:"hostname"`
-	Stop_time float64 `json:"stop_time"` // This is a unix epoch time.
+	Type     string  `json:"type"` // "cycle-stop"
+	ListName string  `json:"list_name"`
+	ID       float64 `json:"id"`
+	Hostname string  `json:"hostname"`
+	StopTime float64 `json:"stop_time"` // This is a unix epoch time.
 }
 
 // ParseRaw parses JSONL files containing the four JSON lines described above,
@@ -202,7 +202,7 @@ func ParseRaw(data []byte, connTime time.Time) (schema.PTTestRaw, error) {
 					rtt = append(rtt, oneReply.RTT)
 				}
 				probes = append(probes, schema.HopProbe{Flowid: int64(oneProbe.Flowid), Rtt: rtt})
-				ttl = int64(oneProbe.Ttl)
+				ttl = int64(oneProbe.TTL)
 			}
 			links = append(links, schema.HopLink{HopDstIP: oneLink.Addr, TTL: ttl, Probes: probes})
 		}
@@ -222,12 +222,12 @@ func ParseRaw(data []byte, connTime time.Time) (schema.PTTestRaw, error) {
 		SchemaVersion:          "1",
 		UUID:                   uuid,
 		TestTime:               connTime,
-		StartTime:              int64(cycleStart.Start_time),
-		StopTime:               int64(cycleStop.Stop_time),
+		StartTime:              int64(cycleStart.StartTime),
+		StopTime:               int64(cycleStop.StopTime),
 		ScamperVersion:         tracelb.Version,
 		ServerIP:               tracelb.Src,
 		ClientIP:               tracelb.Dst,
-		ProbeSize:              int64(tracelb.Probe_size),
+		ProbeSize:              int64(tracelb.ProbeSize),
 		ProbeC:                 int64(tracelb.Probec),
 		Hop:                    hops,
 		CachedResult:           resultFromCache,

--- a/parser/pt_test.go
+++ b/parser/pt_test.go
@@ -110,8 +110,8 @@ func TestParseFirstLine(t *testing.T) {
 	}
 }
 
-func TestCreateTestId(t *testing.T) {
-	test_id := parser.CreateTestId("20170501T000000Z-mlab1-acc02-paris-traceroute-0000.tgz", "20170501T23:53:10Z-98.162.212.214-53849-64.86.132.75-42677.paris")
+func TestCreateTestID(t *testing.T) {
+	test_id := parser.CreateTestID("20170501T000000Z-mlab1-acc02-paris-traceroute-0000.tgz", "20170501T23:53:10Z-98.162.212.214-53849-64.86.132.75-42677.paris")
 	if test_id != "2017/05/01/mlab1.acc02/20170501T23:53:10Z-98.162.212.214-53849-64.86.132.75-42677.paris.gz" {
 		log.Println(test_id)
 		t.Errorf("Error in creating test id!\n")

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,3 +1,4 @@
+// Package schema will be deprecated soon. Do not use.
 package schema
 
 import (
@@ -6,6 +7,7 @@ import (
 	"github.com/m-lab/uuid-annotator/annotator"
 )
 
+// HopIP will be deprecated soon. Do not use.
 type HopIP struct {
 	IP       string                 `json:"ip"`
 	Hostname string                 `json:"hostname"`
@@ -13,23 +15,27 @@ type HopIP struct {
 	Network  *annotator.Network     `json:"network"`
 }
 
+// HopProbe will be deprecated soon. Do not use.
 type HopProbe struct {
 	Flowid int64     `json:"flowid"`
 	Rtt    []float64 `json:"rtt"`
 }
 
+// HopLink will be deprecated soon. Do not use.
 type HopLink struct {
 	HopDstIP string     `json:"hop_dst_ip"`
 	TTL      int64      `json:"ttl"`
 	Probes   []HopProbe `json:"probes"`
 }
 
+// ScamperHop will be deprecated soon. Do not use.
 type ScamperHop struct {
 	Source HopIP     `json:"source"`
 	Linkc  int64     `json:"linkc"`
 	Links  []HopLink `json:"link"`
 }
 
+// PTTestRaw will be deprecated soon. Do not use.
 type PTTestRaw struct {
 	SchemaVersion          string       `json:"schema_version" bigquery:"schema_version"`
 	UUID                   string       `json:"uuid" bigquery:"uuid"`

--- a/tracer/scamper.go
+++ b/tracer/scamper.go
@@ -102,7 +102,7 @@ func (*Scamper) generateFilename(cookie string, t time.Time) string {
 	return t.Format("20060102T150405Z") + "_" + uuid.FromCookie(uint64(c)) + ".json"
 }
 
-// New version that create test from cached trace
+// TraceFromCachedTrace creates test from cached trace.
 func (s *Scamper) TraceFromCachedTrace(conn connection.Connection, t time.Time, cachedTest ipcache.TracerouteData) error {
 	dir, err := createTimePath(s.OutputPath, t)
 	if err != nil {

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -58,6 +58,7 @@ var (
 
 	// hostname of the current machine. Only call os.Hostname once, because the
 	// result should never change.
+	//lint:ignore U1000 hostname is used for testing.
 	hostname string
 
 	// log.Fatal turned into a variable to aid in testing of error conditions.
@@ -83,6 +84,7 @@ type Metadata struct {
 // extractUUID retrieves the UUID from a cached line.
 //
 // TODO: Eliminate the need to unmarshal data we marshaled in the first place.
+//lint:ignore U1000 extractUUID is used for testing.
 func extractUUID(metaline string) string {
 	var metaResult Metadata
 	err := json.Unmarshal([]byte(metaline), &metaResult)


### PR DESCRIPTION
This commit makes changes to this repo's Go source files (excluding
the "*_test.go" files) so they would pass the following tools that
check for correctness and style:

  gofmt
  goimports
  golint
  go vet
  staticcheck

There is only one remaining "golint" warning in "parser/pt.go"
but we can ignore it because this file will soon be deprecated.

There is no code change in this commit that would result in a
different behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/95)
<!-- Reviewable:end -->
