### PR TITLE
Code cleanup and some refactoring

### DIFF
--- a/caller_test.go
+++ b/caller_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -14,11 +15,18 @@ import (
 	"github.com/m-lab/tcp-info/eventsocket"
 )
 
+func init() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
+
 func TestMetrics(t *testing.T) {
 	promtest.LintMetrics(t)
 }
 
 func TestMain(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Skipping for non-linux environment", runtime.GOOS)
+	}
 	dir, err := ioutil.TempDir("", "TestMain")
 	rtx.Must(err, "Could not create temp dir")
 	defer os.RemoveAll(dir)
@@ -41,6 +49,9 @@ func TestMain(t *testing.T) {
 }
 
 func TestScamper(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Skipping for non-linux environment", runtime.GOOS)
+	}
 	dir, err := ioutil.TempDir("", "TestMain")
 	rtx.Must(err, "Could not create temp dir")
 	defer os.RemoveAll(dir)

--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -2,6 +2,7 @@ package connection
 
 import (
 	"errors"
+	"log"
 	"net"
 	"reflect"
 	"strings"
@@ -10,6 +11,10 @@ import (
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/tcp-info/inetdiag"
 )
+
+func init() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
 
 func TestUUID(t *testing.T) {
 	conn := Connection{Cookie: "1be3"}

--- a/connectionlistener/connectionlistener_test.go
+++ b/connectionlistener/connectionlistener_test.go
@@ -29,16 +29,16 @@ type fakeTracer struct {
 	wg    sync.WaitGroup
 }
 
-func (ft *fakeTracer) Trace(conn connection.Connection, t time.Time) (string, error) {
+func (ft *fakeTracer) Trace(conn connection.Connection, t time.Time) ([]byte, error) {
 	ft.mutex.Lock() // Must have a lock to avoid race conditions around the append.
 	defer ft.mutex.Unlock()
 	log.Println("Tracing", conn)
 	ft.ips = append(ft.ips, conn.RemoteIP)
 	ft.wg.Done()
-	return "Fake test result", nil
+	return []byte("Fake test result"), nil
 }
 
-func (ft *fakeTracer) TraceFromCachedTrace(conn connection.Connection, t time.Time, cachedTest string) error {
+func (ft *fakeTracer) TraceFromCachedTrace(conn connection.Connection, t time.Time, cachedTest []byte) error {
 	log.Println("Create cached test for: ", conn)
 	return nil
 }

--- a/connectionlistener/connectionlistener_test.go
+++ b/connectionlistener/connectionlistener_test.go
@@ -23,6 +23,10 @@ import (
 	"github.com/m-lab/tcp-info/eventsocket"
 )
 
+func init() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
+
 type fakeTracer struct {
 	ips   []string
 	mutex sync.Mutex

--- a/connectionpoller/connectionpoller_test.go
+++ b/connectionpoller/connectionpoller_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -15,6 +16,10 @@ import (
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/traceroute-caller/connection"
 )
+
+func init() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
 
 func TestParseIPAndPort(t *testing.T) {
 	ip, port, err := parseIPAndPort("[2620:0:1003:416:a0ad:fd1a:62f:c862]:53890")
@@ -144,6 +149,9 @@ func (tf *testFinder) GetConnections() map[connection.Connection]struct{} {
 func TestConnectionPollerConstruction(t *testing.T) {
 	// The only thing we can verify by default is that the code does not crash.
 	// Which is not nothing, but it's not a lot.
+	if runtime.GOOS != "linux" {
+		t.Skip("Skipping for non-linux environment", runtime.GOOS)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	var tt testTracer

--- a/connectionpoller/connectionpoller_test.go
+++ b/connectionpoller/connectionpoller_test.go
@@ -123,11 +123,11 @@ func TestGetConnectionsWithFakeSS(t *testing.T) {
 
 type testTracer struct{}
 
-func (tt *testTracer) Trace(conn connection.Connection, t time.Time) (string, error) {
-	return "Fake Trace test", nil
+func (tt *testTracer) Trace(conn connection.Connection, t time.Time) ([]byte, error) {
+	return []byte("Fake Trace test"), nil
 }
 
-func (tt *testTracer) TraceFromCachedTrace(conn connection.Connection, t time.Time, cachedTest string) error {
+func (tt *testTracer) TraceFromCachedTrace(conn connection.Connection, t time.Time, cachedTest []byte) error {
 	return nil
 }
 

--- a/ipcache/ipcache.go
+++ b/ipcache/ipcache.go
@@ -22,15 +22,15 @@ var (
 
 // Tracer is the generic interface for all things that can perform a traceroute.
 type Tracer interface {
-	Trace(conn connection.Connection, t time.Time) (string, error)
-	TraceFromCachedTrace(conn connection.Connection, t time.Time, cachedTest string) error
+	Trace(conn connection.Connection, t time.Time) ([]byte, error)
+	TraceFromCachedTrace(conn connection.Connection, t time.Time, cachedTest []byte) error
 	DontTrace(conn connection.Connection, err error)
 }
 
 // cachedTest is a single entry in the cache of traceroute results.
 type cachedTest struct {
 	timeStamp time.Time
-	data      string
+	data      []byte
 	dataReady chan struct{}
 	err       error
 }
@@ -67,7 +67,7 @@ func (rc *RecentIPCache) getTracer() Tracer {
 // Trace performs a trace and adds it to the cache. It calls the methods of the
 // tracer, so if those create files on disk, then files on disk will be created
 // as a side effect.
-func (rc *RecentIPCache) Trace(conn connection.Connection) (string, error) {
+func (rc *RecentIPCache) Trace(conn connection.Connection) ([]byte, error) {
 	c, cached := rc.getEntry(conn.RemoteIP)
 	t := rc.getTracer()
 	if cached {
@@ -77,7 +77,7 @@ func (rc *RecentIPCache) Trace(conn connection.Connection) (string, error) {
 			return c.data, nil
 		}
 		t.DontTrace(conn, c.err)
-		return "", c.err
+		return nil, c.err
 	}
 	c.data, c.err = t.Trace(conn, c.timeStamp)
 	close(c.dataReady)

--- a/ipcache/ipcache_test.go
+++ b/ipcache/ipcache_test.go
@@ -17,6 +17,10 @@ import (
 	pipe "gopkg.in/m-lab/pipe.v3"
 )
 
+func init() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
+
 type testTracer struct {
 	calls  int
 	cctest int

--- a/ipcache/ipcache_test.go
+++ b/ipcache/ipcache_test.go
@@ -22,12 +22,12 @@ type testTracer struct {
 	cctest int
 }
 
-func (tf *testTracer) Trace(conn connection.Connection, t time.Time) (string, error) {
+func (tf *testTracer) Trace(conn connection.Connection, t time.Time) ([]byte, error) {
 	tf.calls++
-	return "Fake trace test " + conn.RemoteIP, nil
+	return []byte("Fake trace test " + conn.RemoteIP), nil
 }
 
-func (tf *testTracer) TraceFromCachedTrace(conn connection.Connection, t time.Time, cachedTest string) error {
+func (tf *testTracer) TraceFromCachedTrace(conn connection.Connection, t time.Time, cachedTest []byte) error {
 	tf.cctest++
 	return nil
 }
@@ -53,7 +53,7 @@ func TestTrace(t *testing.T) {
 	if err != nil {
 		t.Error("trace not working correctly.")
 	}
-	if tmp != "Fake trace test 1.1.1.2" {
+	if string(tmp) != "Fake trace test 1.1.1.2" {
 		t.Error("cache not trace correctly ")
 	}
 
@@ -68,7 +68,7 @@ func TestTrace(t *testing.T) {
 	if err != nil {
 		t.Error("trace not working correctly.")
 	}
-	if t2 != "Fake trace test 1.1.1.5" {
+	if string(t2) != "Fake trace test 1.1.1.5" {
 		t.Error("cache did not trace")
 	}
 	if tt.cctest != 0 {
@@ -148,19 +148,19 @@ type pausingTracer struct {
 	successes            int64
 }
 
-func (pt *pausingTracer) Trace(conn connection.Connection, t time.Time) (string, error) {
+func (pt *pausingTracer) Trace(conn connection.Connection, t time.Time) ([]byte, error) {
 	randomDelay()
 	if conn.RemoteIP == pt.traceToBlock || conn.RemoteIP == pt.traceToBlockAndError {
 		<-pt.ctx.Done()
 	}
 	atomic.AddInt64(&pt.successes, 1)
 	if conn.RemoteIP == pt.traceToError || conn.RemoteIP == pt.traceToBlockAndError {
-		return "", errors.New(pipe.ErrTimeout.Error())
+		return nil, errors.New(pipe.ErrTimeout.Error())
 	}
-	return "Trace to " + conn.RemoteIP, nil
+	return []byte("Trace to " + conn.RemoteIP), nil
 }
 
-func (pt *pausingTracer) TraceFromCachedTrace(conn connection.Connection, t time.Time, cachedTest string) error {
+func (pt *pausingTracer) TraceFromCachedTrace(conn connection.Connection, t time.Time, cachedTest []byte) error {
 	randomDelay()
 	atomic.AddInt64(&pt.successes, 1)
 	return nil
@@ -204,7 +204,7 @@ func TestCacheWithBlockedTests(t *testing.T) {
 				if err != nil {
 					t.Errorf("Trace %d not done correctly.", j)
 				}
-				if s != expected {
+				if string(s) != expected {
 					t.Errorf("Bad trace output: %q, should be %s", s, expected)
 				}
 			}

--- a/tracer/scamper.go
+++ b/tracer/scamper.go
@@ -205,7 +205,6 @@ func (d *ScamperDaemon) TraceAll(connections []connection.Connection) {
 }
 
 func traceAndWrite(fn string, cmd pipe.Pipe, conn connection.Connection, t time.Time, timeout time.Duration) ([]byte, error) {
-
 	data, err := runTrace(cmd, conn, timeout)
 	if err != nil {
 		return nil, err

--- a/tracer/scamper_test.go
+++ b/tracer/scamper_test.go
@@ -128,6 +128,9 @@ func TestExistingFileStopsDaemonCreation(t *testing.T) {
 	// socket needs to exist in a well-known location. If there is already a file
 	// in that well-known location, then that is an indication that something has
 	// gone wrong with the surrounding environment.
+	if runtime.GOOS != "linux" {
+		t.Skip("Skipping for non-linux environment", runtime.GOOS)
+	}
 
 	defer func() {
 		logFatal = log.Fatal

--- a/tracer/scamper_test.go
+++ b/tracer/scamper_test.go
@@ -235,13 +235,6 @@ func TestTraceTimeout(t *testing.T) {
 		Warts2JSONBinary: "cat",
 	}
 
-	defer func() {
-		r := recover()
-		if r != nil {
-			t.Error("timeout error should NOT trigger recover", r)
-		}
-	}()
-
 	c := connection.Connection{
 		Cookie:   "1",
 		RemoteIP: "1.2.3.4",
@@ -334,8 +327,8 @@ func TestCreateCacheTest(t *testing.T) {
 	}
 }
 
-func TestRecovery(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "TestRecovery")
+func TestGenerateFilenameError(t *testing.T) {
+	tempdir, err := ioutil.TempDir("", "TestGenerateFilenameError")
 	rtx.Must(err, "Could not create tempdir")
 	defer os.RemoveAll(tempdir)
 
@@ -350,18 +343,22 @@ func TestRecovery(t *testing.T) {
 			OutputPath:     tempdir,
 			ScamperTimeout: 1 * time.Minute,
 		},
-		AttachBinary:     "echo",
+		AttachBinary:     "false",
 		Warts2JSONBinary: "cat",
 	}
 
 	c := connection.Connection{
-		Cookie: "not a number in base 16 at all",
+		Cookie: "not a valid base 16 number",
 	}
 
-	// Run both trace methods.
-	d.TraceAll([]connection.Connection{c})
 	_, _ = d.Trace(c, time.Now())
-	// If this doesn't crash, then the recovery process works!
+
+	s := &Scamper{
+		OutputPath:     tempdir,
+		ScamperTimeout: 1 * time.Minute,
+	}
+
+	_, _ = s.Trace(c, time.Now())
 }
 
 func TestExtractUUID(t *testing.T) {

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -100,9 +100,9 @@ type Metadata struct {
 // extractUUID retrieves the UUID from a cached line.
 //
 // TODO: Eliminate the need to unmarshal data we marshaled in the first place.
-func extractUUID(metaline string) string {
+func extractUUID(metaline []byte) string {
 	var metaResult Metadata
-	err := json.Unmarshal([]byte(metaline), &metaResult)
+	err := json.Unmarshal(metaline, &metaResult)
 	if err != nil {
 		log.Println("Could not parse cached results:", metaline)
 		return ""
@@ -114,7 +114,7 @@ func extractUUID(metaline string) string {
 // be. Parameter isCache indicates whether this meta line is for an original
 // trace test or a cached test, and parameter cachedUUID is the original test if
 // isCache is 1.
-func GetMetaline(conn connection.Connection, isCache bool, cachedUUID string) string {
+func GetMetaline(conn connection.Connection, isCache bool, cachedUUID string) []byte {
 	// Write the UUID as the first line of the file. If we want to add other
 	// metadata, this is the place to do it.
 	//
@@ -133,7 +133,7 @@ func GetMetaline(conn connection.Connection, isCache bool, cachedUUID string) st
 
 	metaJSON, _ := json.Marshal(meta)
 
-	return string(metaJSON) + "\n"
+	return append(metaJSON, byte('\n'))
 }
 
 // createTimePath returns a string with date in format prefix/yyyy/mm/dd/ after


### PR DESCRIPTION
Updates tests to include file/linenum
Updates tests to avoid when not on linux
refactors generateFilename
starts extracting code that is common between scamper and scamper-daemon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/104)
<!-- Reviewable:end -->
