### PR TITLE
Increase scamper's number of packets per second to send

### DIFF
--- a/tracer/scamper.go
+++ b/tracer/scamper.go
@@ -150,7 +150,7 @@ func (d *ScamperDaemon) MustStart(ctx context.Context) {
 		logFatal("The control socket file must not already exist: ", err)
 	}
 	defer os.Remove(d.ControlSocket)
-	command := exec.Command(d.Binary, "-U", d.ControlSocket)
+	command := exec.Command(d.Binary, "-U", d.ControlSocket, "-p", "10000")
 	// Start is non-blocking.
 	rtx.Must(command.Start(), "Could not start daemon")
 


### PR DESCRIPTION
We have recently noticed that the majority of traceroutes have been
timing out: https://github.com/m-lab/traceroute-caller/issues/102.
This commit sets PPS to send to its allowed maximum value of 10,000
as suggested by Matthew Luckie.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/106)
<!-- Reviewable:end -->
