### PR TITLE
Fix the format of scamper command argument

### DIFF
--- a/tracer/scamper.go
+++ b/tracer/scamper.go
@@ -108,13 +108,13 @@ func (s *Scamper) trace(conn connection.Connection, t time.Time) (string, error)
 	}
 	tracelbCmd = append(tracelbCmd, conn.RemoteIP)
 	cmd := shx.Pipe(
-		shx.Exec(s.Binary, "-I", fmt.Sprintf("%q", strings.Join(tracelbCmd, " ")), "-o-", "-O", "json"),
+		shx.Exec(s.Binary, "-I", strings.Join(tracelbCmd, " "), "-o-", "-O", "json"),
 		shx.Write(&buff),
 	)
 
 	// Now run the command.
-	log.Printf("Trace started in context %p (%s -I \"%s\" -o- -O json)\n",
-		ctx, s.Binary, strings.Join(tracelbCmd, " "))
+	log.Printf("Trace started in context %p (%s)\n", ctx,
+		[]interface{}{s.Binary, "-I", fmt.Sprintf("%q", strings.Join(tracelbCmd, " ")), "-o-", "-O", "json"})
 	start := time.Now()
 	err = cmd.Run(ctx, shx.New())
 	latency := time.Since(start).Seconds()

--- a/tracer/scamper.go
+++ b/tracer/scamper.go
@@ -107,14 +107,14 @@ func (s *Scamper) trace(conn connection.Connection, t time.Time) (string, error)
 		tracelbCmd = append(tracelbCmd, []string{"-O", "ptr"}...)
 	}
 	tracelbCmd = append(tracelbCmd, conn.RemoteIP)
+	iVal := strings.Join(tracelbCmd, " ")
 	cmd := shx.Pipe(
-		shx.Exec(s.Binary, "-I", strings.Join(tracelbCmd, " "), "-o-", "-O", "json"),
+		shx.Exec(s.Binary, "-I", iVal, "-o-", "-O", "json"),
 		shx.Write(&buff),
 	)
 
 	// Now run the command.
-	log.Printf("Trace started in context %p (%s)\n", ctx,
-		[]interface{}{s.Binary, "-I", fmt.Sprintf("%q", strings.Join(tracelbCmd, " ")), "-o-", "-O", "json"})
+	log.Printf("Trace started in context %p (%s -I %q -o- -O json)\n", ctx, s.Binary, iVal)
 	start := time.Now()
 	err = cmd.Run(ctx, shx.New())
 	latency := time.Since(start).Seconds()

--- a/tracer/scamper_test.go
+++ b/tracer/scamper_test.go
@@ -52,7 +52,7 @@ func TestScamper(t *testing.T) {
 	uuid, err := conn.UUID()
 	rtx.Must(err, "Could not make uuid")
 	expected := `{"UUID":"` + uuid + `","TracerouteCallerVersion":"` + prometheusx.GitShortCommit + `","CachedResult":false,"CachedUUID":""}
--I "tracelb -P icmp-echo -q 3 -W 0 -O ptr 10.1.1.1" -o- -O json
+-I tracelb -P icmp-echo -q 3 -W 0 -O ptr 10.1.1.1 -o- -O json
 `
 	if strings.TrimSpace(out) != strings.TrimSpace(expected) {
 		t.Error("Bad output:", out)


### PR DESCRIPTION
The flags that are passed to scamper's command (e.g., tracelb) via
the -I flag should be specified as one string argument.	Quotes are
only needed when using the shell or printing log messages.

Tests:
    - go test ./...
    - docker-compose uy (tracetool=scamper)
      docker exec -it trc_traceroute-caller_1 apt-get update
      ...
      scamper.go:134: Trace succeeded in context 0xc0000bd620
      ...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/111)
<!-- Reviewable:end -->
