### PR TITLE
Use tini to reap orphan child process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ FROM ubuntu:20.04
 # Install all the packages we need and then remove the apt-get lists.
 # iproute2 gives us ss
 RUN apt-get update && \
-    apt-get install -y iproute2 && \
+    apt-get install -y iproute2 tini && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -73,4 +73,4 @@ RUN which sc_warts2json
 RUN which ss
 
 WORKDIR /
-ENTRYPOINT ["/traceroute-caller"]
+ENTRYPOINT ["tini", "--", "/traceroute-caller"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -63,9 +63,9 @@ services:
       - -outputPath=/local/traceroute
       - -poll=false
       - -tcpinfo.eventsocket=/local/tcpevents.sock
-      - -tracetool=scamper-daemon
-      - -scamper.timeout=3600s
-      - -scamper.tracelb-ptr=false
-      - -scamper.tracelb-W=30
-      - -IPCacheTimeout=600s
-      - -IPCacheUpdatePeriod=60s
+      - -tracetool=scamper
+      - -IPCacheTimeout=10m
+      - -IPCacheUpdatePeriod=1m
+      - -scamper.timeout=30m
+      - -scamper.tracelb-W=15
+      #- -scamper.tracelb-ptr=false


### PR DESCRIPTION
This commit uses tini to start traceroute-caller in order to
reap its orphaned child processes.

Also, for local debugging via docker-compose, this
commit uses the same parameters as are specified in
k8s/daemonsets/templates.jsonnet.

The changes were tested locally via docker-compose, making
sure that there are no orphan processes after traceroute-caller
runs scamper.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/112)
<!-- Reviewable:end -->
