### PR TITLE
Remove paris-traceroute from the repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "third_party/libparistraceroute"]
-	path = third_party/libparistraceroute
-	url = https://github.com/libparistraceroute/libparistraceroute.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,16 +33,6 @@ RUN ./configure --prefix=/scamper
 RUN make -j 8
 RUN make install
 
-# Build and install paris-traceroute
-RUN mkdir /pt-src
-ADD ./third_party/libparistraceroute/ /pt-src
-WORKDIR /pt-src
-RUN mkdir -p m4
-RUN ./autogen.sh
-RUN ./configure --prefix=/paris-traceroute
-RUN make -j 8
-RUN make install
-
 # Create an image for the binaries that are called by traceroute-caller without
 # any of the build tools.
 FROM ubuntu:20.04
@@ -59,14 +49,12 @@ COPY --from=build_caller /go/bin/traceroute-caller /
 # Bring the dynamically-linked traceroute binaries and their associated
 # libraries from their build image.
 COPY --from=build_tracers /scamper /usr/local
-COPY --from=build_tracers /paris-traceroute /usr/local
 
 # They are dynamically-linked, so make sure to run ldconfig to locate all new
 # libraries.
 RUN ldconfig
 
 # Verify that all the binaries we depend on are actually available
-RUN which paris-traceroute
 RUN which scamper
 RUN which sc_attach
 RUN which sc_warts2json


### PR DESCRIPTION
Since traceroute-caller no longer needs or supports paris-traceroute,
this commit removes third_party/libparistraceroute and the instructions
in Dockerfile to build it.

Tested the changes locally by building the traceroute-caller container
and running traceroutes via docker-compose.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/113)
<!-- Reviewable:end -->
