### PR TITLE
Add bigquery key-value tags to ScamperOutput struct

### DIFF
--- a/parser/scamper_output.go
+++ b/parser/scamper_output.go
@@ -47,10 +47,10 @@ type Reply struct {
 	Rx       TS      `json:"rx"`
 	TTL      int     `json:"ttl"`
 	RTT      float64 `json:"rtt"`
-	IcmpType int     `json:"icmp_type"`
-	IcmpCode int     `json:"icmp_code"`
-	IcmpQTos int     `json:"icmp_q_tos"`
-	IcmpQTTL int     `json:"icmp_q_ttl"`
+	IcmpType int     `json:"icmp_type" bigquery:"icmp_type"`
+	IcmpCode int     `json:"icmp_code" bigquer:"icmp_code"`
+	IcmpQTos int     `json:"icmp_q_tos" bigquery:"icmp_q_tos"`
+	IcmpQTTL int     `json:"icmp_q_ttl" bigquery:"icmp_q_ttl"`
 }
 
 // Probe describes a single probe message, and all the associated replies.
@@ -74,7 +74,7 @@ type ScamperLink struct {
 type ScamperNode struct {
 	Addr  string          `json:"addr"`
 	Name  string          `json:"name"`
-	QTTL  int             `json:"q_ttl"`
+	QTTL  int             `json:"q_ttl" bigquery:"q_ttl"`
 	Linkc int64           `json:"linkc"`
 	Links [][]ScamperLink `json:"links"`
 }
@@ -94,10 +94,10 @@ type ScamperOutput struct {
 // CyclestartLine contains the information about the scamper "cyclestart"
 type CyclestartLine struct {
 	Type      string  `json:"type"`
-	ListName  string  `json:"list_name"`
+	ListName  string  `json:"list_name" bigquery:"list_name"`
 	ID        float64 `json:"id"`
 	Hostname  string  `json:"hostname"`
-	StartTime float64 `json:"start_time"`
+	StartTime float64 `json:"start_time" bigquery:"start_time"`
 }
 
 // TracelbLine contains the actual scamper trace details.
@@ -110,16 +110,16 @@ type TracelbLine struct {
 	Src         string        `json:"src"`
 	Dst         string        `json:"dst"`
 	Start       TS            `json:"start"`
-	ProbeSize   float64       `json:"probe_size"`
+	ProbeSize   float64       `json:"probe_size" bigquery:"probe_size"`
 	Firsthop    float64       `json:"firsthop"`
 	Attempts    float64       `json:"attempts"`
 	Confidence  float64       `json:"confidence"`
 	Tos         float64       `json:"tos"`
 	Gaplint     float64       `json:"gaplint"`
-	WaitTimeout float64       `json:"wait_timeout"`
-	WaitProbe   float64       `json:"wait_probe"`
+	WaitTimeout float64       `json:"wait_timeout" bigquery:"wait_timeout"`
+	WaitProbe   float64       `json:"wait_probe" bigquery:"wait_probe"`
 	Probec      float64       `json:"probec"`
-	ProbecMax   float64       `json:"probec_max"`
+	ProbecMax   float64       `json:"probec_max" bigquery:"probec_max"`
 	Nodec       float64       `json:"nodec"`
 	Linkc       float64       `json:"linkc"`
 	Nodes       []ScamperNode `json:"nodes"`
@@ -129,10 +129,10 @@ type TracelbLine struct {
 // ListName, hostname seem to match CyclestartLine
 type CyclestopLine struct {
 	Type     string  `json:"type"`
-	ListName string  `json:"list_name"`
+	ListName string  `json:"list_name" bigquery:"list_name"`
 	ID       float64 `json:"id"`
 	Hostname string  `json:"hostname"`
-	StopTime float64 `json:"stop_time"`
+	StopTime float64 `json:"stop_time" bigquery:"stop_time"`
 }
 
 // ParseTraceroute parses scamper output in JSONL format and returns it.


### PR DESCRIPTION
When loading data to BigQuery, the Gardener is not able to find some fields from the ScamperOutput struct such as CycleStart.ListName because it does not have a mapping to the list_name tag in BigQuery.

Adding bigquery tags to the struct.

Example error:
```json
{
  "textPayload": "2021/09/20 10:58:31 actions.go:126: --- 20210919:ndt/scamper1 Load {Location: \"gs://etl-mlab-sandbox/ndt/scamper1/2021/09/19/20210919T003001.876612Z-scamper1-mlab1-bog03-ndt.tgz.json\"; Message: \"Error while reading data, error message: JSON parsing error in row starting at position 0: No such field: raw.CycleStart.list_name.\"; Reason: \"invalid\"}\n",
  "insertId": "8jl2j1xpvjsntyhv",
  "resource": {
    "type": "k8s_container",
    "labels": {
      "cluster_name": "data-processing",
      "location": "us-east1",
      "pod_name": "etl-gardener-universal-67fb879b4b-kfk7t",
      "namespace_name": "default",
      "project_id": "mlab-sandbox",
      "container_name": "etl-gardener"
    }
  },
  "timestamp": "2021-09-20T10:58:31.514515778Z",
  "severity": "ERROR",
  "labels": {
    "k8s-pod/pod-template-hash": "67fb879b4b",
    "k8s-pod/run": "etl-gardener-universal",
    "compute.googleapis.com/resource_name": "gke-data-processing-default-pool-f4fc41ed-xqmo"
  },
  "logName": "projects/mlab-sandbox/logs/stderr",
  "receiveTimestamp": "2021-09-20T10:58:35.364763641Z"
}
```
https://pantheon.corp.google.com/logs/query;cursorTimestamp=2021-09-20T10:58:31.514515778Z;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22mlab-sandbox%22%0Aresource.labels.location%3D%22us-east1%22%0Aresource.labels.cluster_name%3D%22data-processing%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.k8s-pod%2Frun%3D%22etl-gardener-universal%22%20severity%3E%3DDEFAULT%0A%22scamper1%22%0Atimestamp%3D%222021-09-20T10:58:31.514515778Z%22%0AinsertId%3D%228jl2j1xpvjsntyhv%22%0Atimestamp%3D%222021-09-20T10:58:31.514515778Z%22%0AinsertId%3D%228jl2j1xpvjsntyhv%22;timeRange=2021-09-20T13:56:20.777Z%2F2021-09-20T13:56:20.777Z--PT6H?project=mlab-sandbox

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/123)
<!-- Reviewable:end -->
