### PR TITLE
Add missing y to bigquery tag

### DIFF
--- a/parser/scamper_output.go
+++ b/parser/scamper_output.go
@@ -48,7 +48,7 @@ type Reply struct {
 	TTL      int     `json:"ttl"`
 	RTT      float64 `json:"rtt"`
 	IcmpType int     `json:"icmp_type" bigquery:"icmp_type"`
-	IcmpCode int     `json:"icmp_code" bigquer:"icmp_code"`
+	IcmpCode int     `json:"icmp_code" bigquery:"icmp_code"`
 	IcmpQTos int     `json:"icmp_q_tos" bigquery:"icmp_q_tos"`
 	IcmpQTTL int     `json:"icmp_q_ttl" bigquery:"icmp_q_ttl"`
 }


### PR DESCRIPTION
Upon testing, I found the IcmpCode field did not get updated with the bigquery tag. This is because there is a missing "y" in its tag.
![Screenshot 2021-09-21 2 45 38 PM](https://user-images.githubusercontent.com/21001496/134229370-eaf5b5ae-b93a-45d9-a8e8-b216aa74b306.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/124)
<!-- Reviewable:end -->
