### PR TITLE
Remove code related to scamper daemon mode

### DIFF
--- a/caller_test.go
+++ b/caller_test.go
@@ -33,7 +33,6 @@ func TestMainWithConnectionListener(t *testing.T) {
 	*eventsocket.Filename = dir + "/events.sock"
 	*tracerouteOutput = dir
 	*hopAnnotationOutput = dir
-	tracerType.Value = "scamper"
 
 	ctx, cancel = context.WithCancel(context.Background())
 	go func(t *testing.T) {
@@ -49,7 +48,6 @@ func TestMainWithConnectionListener(t *testing.T) {
 }
 
 func TestMainWithBadArgs(t *testing.T) {
-	tracerType.Value = "scamper"
 	*eventsocket.Filename = ""
 	*tracerouteOutput = "/tmp/"
 	*hopAnnotationOutput = "/tmp/"

--- a/connectionlistener/connectionlistener.go
+++ b/connectionlistener/connectionlistener.go
@@ -108,8 +108,8 @@ func (cl *connectionListener) traceAnnotateAndArchive(ctx context.Context, conn 
 	}
 }
 
-// New returns an eventsocket.Handler that will call the passed-in scamper
-// daemon on every closed connection.
+// New returns an eventsocket.Handler that will use the passed-in argument
+// ipCache to run a trace to a connection when it is closed.
 func New(creator connection.Creator, ipCache *ipcache.RecentIPCache, hopAnnotator *hopannotation.HopCache) eventsocket.Handler {
 	return &connectionListener{
 		conns:        make(map[string]connection.Connection),

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,11 +60,10 @@ services:
         delay: 5s
     command:
       - -prometheusx.listen-address=:9992
-      - -traceroute-output=/local/traceroute
+      - -traceroute-output=/local/scamper1
       - -hopannotation-output=/local/hopannotation1
       - -tcpinfo.eventsocket=/local/tcpevents.sock
       - -ipservice.sock=/local/uuid-annotator.sock
-      - -tracetool=scamper
       - -IPCacheTimeout=10m
       - -IPCacheUpdatePeriod=1m
       - -scamper.timeout=30m

--- a/tracer/scamper.go
+++ b/tracer/scamper.go
@@ -5,29 +5,24 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
-	"os/exec"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
-	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/go/shx"
 	"github.com/m-lab/traceroute-caller/connection"
 	"github.com/m-lab/uuid"
 )
 
-// Scamper uses scamper in non-daemon mode to perform traceroutes. This is much
-// less efficient, but when scamper crashes, it has a much lower "blast radius".
+// Scamper invokes an instance of the scamper tool for each traceroute.
 type Scamper struct {
-	Binary, OutputPath string
-	ScamperTimeout     time.Duration
-	TracelbPTR         bool
-	TracelbWaitProbe   int
+	Binary           string
+	OutputPath       string
+	ScamperTimeout   time.Duration
+	TracelbPTR       bool
+	TracelbWaitProbe int
 }
 
 // generatesFilename creates the string filename for storing the data.
@@ -108,115 +103,6 @@ func (s *Scamper) trace(conn connection.Connection, t time.Time) ([]byte, error)
 	)
 
 	return traceAndWrite(ctx, "scamper", filename, cmd, conn)
-}
-
-// ScamperDaemon contains a single instance of a scamper process. Once the ScamperDaemon has
-// been started, you can call Trace and then all traces will be centrally run
-// and managed.
-//
-// This approach has the advantage that all traces are centrally managed, which
-// helps prevent problems with overlapping traces. It has the disadvantage that
-// all traces are centrally managed, so if the central daemon goes wrong for
-// some reason, there is a much larger blast radius.
-type ScamperDaemon struct {
-	*Scamper
-	AttachBinary, Warts2JSONBinary, ControlSocket string
-}
-
-// MustStart starts a scamper binary running and listening to the given context.
-// There should only be a single instance of scamper being run by
-// traceroute-caller, and if it can't start, then traceroutes can not be
-// performed.
-//
-// We expect this function to be mostly used as a goroutine:
-//    go d.MustStart(ctx)
-func (d *ScamperDaemon) MustStart(ctx context.Context) {
-	scamperDaemonRunning.Set(1)
-	defer scamperDaemonRunning.Set(0)
-	derivedCtx, derivedCancel := context.WithCancel(ctx)
-	defer derivedCancel()
-	if _, err := os.Stat(d.ControlSocket); !os.IsNotExist(err) {
-		logFatal("The control socket file must not already exist: ", err)
-	}
-	defer os.Remove(d.ControlSocket)
-	cmdFlags := []string{"-U", d.ControlSocket, "-p", "10000"}
-	command := exec.Command(d.Binary, cmdFlags...)
-	// Start is non-blocking.
-	log.Printf("Starting scamper as a daemon: %s %s\n", d.Binary, strings.Join(cmdFlags, " "))
-	rtx.Must(command.Start(), "failed to start daemon")
-
-	// Liveness guarantee: either the process will die and then the derived context
-	// will be canceled, or the context will be canceled and then the process will
-	// be sent SIGKILL. Either way, this function ends with a canceled sub-context
-	// and a process that is either dead or processing SIGKILL.
-	go func() {
-		err := command.Wait()
-		log.Printf("scamper exited with error: %v\n", err)
-		derivedCancel()
-	}()
-	<-derivedCtx.Done()
-
-	// This will only kill the scamper daemon when executed by root, because the
-	// scamper binary is suid root a user can't kill processes owned by root, even
-	// if the user started those processes. This is also why we don't use
-	// CommandContext in the exec package - if the process isn't successfully
-	// killed by SIGKILL, then the code in that package doesn't work correctly.
-	if err := command.Process.Signal(syscall.SIGKILL); err != nil {
-		log.Printf("failed to send SIGKILL to scamper daemon, error: %v\n", err)
-	}
-}
-
-// Trace starts a sc_attach connecting to the scamper process for each
-// connection.
-func (d *ScamperDaemon) Trace(conn connection.Connection, t time.Time) (out []byte, err error) {
-	// TODO Is this still useful?  Does shx.PipeJob we ever panic?
-	defer func() {
-		if r := recover(); r != nil {
-			log.Printf("Recovered (%v) a crashed trace for %v at %v\n", r, conn, t)
-			crashedTraces.WithLabelValues("scamper-daemon").Inc()
-			err = errors.New(fmt.Sprint(r))
-		}
-	}()
-	tracesInProgress.WithLabelValues("scamper-daemon").Inc()
-	defer tracesInProgress.WithLabelValues("scamper-daemon").Dec()
-	return d.trace(conn, t)
-}
-
-// TraceAll runs N independent traces on N passed-in connections.
-func (d *ScamperDaemon) TraceAll(connections []connection.Connection) {
-	for _, c := range connections {
-		log.Printf("PT start: %s %d", c.RemoteIP, c.RemotePort)
-		go func(c connection.Connection) {
-			_, _ = d.Trace(c, time.Now())
-		}(c)
-	}
-}
-
-func (d *ScamperDaemon) trace(conn connection.Connection, t time.Time) ([]byte, error) {
-	// Make sure a directory path based on the current date exists,
-	// generate a filename to save in that directory, and create
-	// a buffer to hold traceroute data.
-	filename, err := generateFilename(d.OutputPath, conn.Cookie, t)
-	if err != nil {
-		return nil, err
-	}
-
-	// Create a context and initialize command execution variables.
-	ctx, cancel := context.WithTimeout(context.Background(), d.ScamperTimeout)
-	defer cancel()
-	tracelbCmd := []string{"tracelb", "-P", "icmp-echo", "-q", "3", "-W", strconv.Itoa(d.TracelbWaitProbe)}
-	if d.TracelbPTR {
-		tracelbCmd = append(tracelbCmd, []string{"-O", "ptr"}...)
-	}
-	tracelbCmd = append(tracelbCmd, conn.RemoteIP)
-	scAttachCmd := []string{d.AttachBinary, "-i-", "-o-", "-U", d.ControlSocket}
-	cmd := shx.Pipe(
-		shx.Exec("echo", tracelbCmd...),
-		shx.Exec(scAttachCmd[0], scAttachCmd[1:]...),
-		shx.Exec(d.Warts2JSONBinary),
-	)
-
-	return traceAndWrite(ctx, "scamper-daemon", filename, cmd, conn)
 }
 
 func traceAndWrite(ctx context.Context, label string, filename string, cmd shx.Job, conn connection.Connection) ([]byte, error) {

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -66,19 +66,10 @@ var (
 		},
 		[]string{"type", "error"},
 	)
-	scamperDaemonRunning = promauto.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "traces_scamper_daemon_running",
-			Help: "Whether the scamper daemon is running or not.",
-		},
-	)
 
 	// hostname of the current machine. Only call os.Hostname once, because the
 	// result should never change.
 	hostname string
-
-	// log.Fatal turned into a variable to aid in testing of error conditions.
-	logFatal = log.Fatal
 )
 
 func init() {


### PR DESCRIPTION
The scamper tool used by traceroute-caller to run traceroutes can
operate in two modes: stand-alone binary mode and daemon mode.
In the stand-alone mode, an instance of scamper is invoked for
each traceroute run.  In the daemon mode, scamper is invoked once
as a daemon to listen on a socket for requests.  The daemon mode,
however, does not work properly and times out when there are many
concurrent requests.  As a result, about 75% of all traceroutes
were timing out.  We are now running scamper in stand-alone mode
and are not supporting the daemon mode anymore.

The changes were tested locally using docker-compose.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/125)
<!-- Reviewable:end -->
