### PR TITLE
Reorganize code in preparation for scamper2 datatype

### DIFF
--- a/caller.go
+++ b/caller.go
@@ -13,6 +13,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"os/exec"
 	"time"
 
 	"github.com/m-lab/go/flagx"
@@ -20,6 +21,7 @@ import (
 	"github.com/m-lab/tcp-info/eventsocket"
 	"github.com/m-lab/traceroute-caller/hopannotation"
 	"github.com/m-lab/traceroute-caller/ipcache"
+	"github.com/m-lab/traceroute-caller/parser"
 	"github.com/m-lab/traceroute-caller/tracer"
 	"github.com/m-lab/traceroute-caller/triggertrace"
 	"github.com/m-lab/uuid-annotator/ipservice"
@@ -27,9 +29,10 @@ import (
 
 var (
 	scamperBin          = flag.String("scamper.bin", "scamper", "The path to the scamper binary.")
-	scamperTimeout      = flag.Duration("scamper.timeout", 900*time.Second, "How long to wait to complete a scamper trace.")
-	scamperPTR          = flag.Bool("scamper.tracelb-ptr", true, "Look up DNS pointer records for IP addresses.")
-	scamperWaitProbe    = flag.Int("scamper.tracelb-W", 25, "How long to wait between probes in 1/100ths of seconds (min 15, max 200).")
+	scamperTimeout      = flag.Duration("scamper.timeout", 900*time.Second, "How long to wait for scamper to complete a traceroute.")
+	scamperTraceType    = flag.String("scamper.trace-type", "mda", "Specify the type of traceroute to run (currently only mda).")
+	scamperTracelbPTR   = flag.Bool("scamper.tracelb-ptr", true, "scamper tracelb option: Look up DNS pointer records for IP addresses.")
+	scamperTracelbW     = flag.Int("scamper.tracelb-W", 25, "scamper tracelb option: Wait time between probes in 1/100ths of seconds (min 15, max 200).")
 	tracerouteOutput    = flag.String("traceroute-output", "/var/spool/scamper1", "The path to store traceroute output.")
 	hopAnnotationOutput = flag.String("hopannotation-output", "/var/spool/hopannotation1", "The path to store hop annotation output.")
 	// Keeping IP cache flags capitalized for backward compatibility.
@@ -62,25 +65,50 @@ func main() {
 		}
 	}()
 
-	// The triggertrace package needs to know which trace tool to
-	// use for running traceroutes, how long to keep traceroute results
-	// in the cache, and which service to use for annotating the hops.
+	// There is a race condition in scamper when it creates its
+	// PRIVSEP_DIR (by default: /var/empty) if it doesn't exist.
+	// The following call is a workaround to make sure PRIVSEP_DIR
+	// already exists before running actual traceroutes which can
+	// happen concurrently.
+	exec.Command(*scamperBin, "-I", "trace -P icmp-paris 127.0.0.1", "-o-", "-O", "json").Run()
+
+	// The triggertrace package needs the following:
+	//   - A traceroute tool for running traceroutes.
+	//   - A traceroute cache to keep traceroute results.
+	//   - A parser to parse traceroutes.
+	//   - A hop annotator for annotating IP addresses.
+	// The traceroute tool (scamper).
 	scamper := &tracer.Scamper{
 		Binary:           *scamperBin,
 		OutputPath:       *tracerouteOutput,
-		ScamperTimeout:   *scamperTimeout,
-		TracelbPTR:       *scamperPTR,
-		TracelbWaitProbe: *scamperWaitProbe,
+		Timeout:          *scamperTimeout,
+		TraceType:        *scamperTraceType,
+		TracelbPTR:       *scamperTracelbPTR,
+		TracelbWaitProbe: *scamperTracelbW,
 	}
+	if err := scamper.Validate(); err != nil {
+		logFatal(err)
+	}
+	// The traceroute cache.
+	// TODO(SaiedKazemi): The name ipcache (in its various forms)
+	// should be changed to trcache because the cache holds traceroutes
+	// values -- IP is simply the key.  Anyway, IP will go away when IP
+	// annonymization is implemented.
 	ipcCfg := ipcache.Config{
 		EntryTimeout: *ipcEntryTimeout,
 		ScanPeriod:   *ipcScanPeriod,
 	}
+	// The traceroute parser.
+	newParser, err := parser.New(*scamperTraceType)
+	if err != nil {
+		logFatal(err)
+	}
+	// The hop annotator.
 	haCfg := hopannotation.Config{
 		AnnotatorClient: ipservice.NewClient(*ipservice.SocketFilename),
 		OutputPath:      *hopAnnotationOutput,
 	}
-	traceHandler, err := triggertrace.NewHandler(ctx, scamper, ipcCfg, haCfg)
+	traceHandler, err := triggertrace.NewHandler(ctx, scamper, ipcCfg, newParser, haCfg)
 	if err != nil {
 		logFatal(fmt.Errorf("%v: %w", errNewHandler, err))
 	}

--- a/caller.go
+++ b/caller.go
@@ -13,7 +13,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"os/exec"
 	"time"
 
 	"github.com/m-lab/go/flagx"
@@ -28,11 +27,14 @@ import (
 )
 
 var (
-	scamperBin          = flag.String("scamper.bin", "scamper", "The path to the scamper binary.")
-	scamperTimeout      = flag.Duration("scamper.timeout", 900*time.Second, "How long to wait for scamper to complete a traceroute.")
-	scamperTraceType    = flag.String("scamper.trace-type", "mda", "Specify the type of traceroute to run (currently only mda).")
-	scamperTracelbPTR   = flag.Bool("scamper.tracelb-ptr", true, "scamper tracelb option: Look up DNS pointer records for IP addresses.")
-	scamperTracelbW     = flag.Int("scamper.tracelb-W", 25, "scamper tracelb option: Wait time between probes in 1/100ths of seconds (min 15, max 200).")
+	scamperBin       = flag.String("scamper.bin", "/usr/local/bin/scamper", "The path to the scamper binary.")
+	scamperTimeout   = flag.Duration("scamper.timeout", 900*time.Second, "How long to wait for scamper to complete a traceroute.")
+	scamperTraceType = flagx.Enum{
+		Options: []string{"mda"}, // "regular" will be added soon
+		Value:   "mda",
+	}
+	scamperTracelbPTR   = flag.Bool("scamper.tracelb-ptr", true, "mda traceroute option: Look up DNS pointer records for IP addresses.")
+	scamperTracelbW     = flag.Int("scamper.tracelb-W", 25, "mda traceroute option: Wait time between probes in 1/100ths of seconds (min 15, max 200).")
 	tracerouteOutput    = flag.String("traceroute-output", "/var/spool/scamper1", "The path to store traceroute output.")
 	hopAnnotationOutput = flag.String("hopannotation-output", "/var/spool/hopannotation1", "The path to store hop annotation output.")
 	// Keeping IP cache flags capitalized for backward compatibility.
@@ -44,8 +46,13 @@ var (
 	logFatal       = log.Fatal
 	errEnvArgs     = errors.New("failed to get args from environment")
 	errEventSocket = errors.New("tcpinfo.eventsocket value was empty")
+	errScamper     = errors.New("failed to configure scamper")
 	errNewHandler  = errors.New("failed to create a triggertrace handler")
 )
+
+func init() {
+	flag.Var(&scamperTraceType, "scamper.trace-type", "Specify the type of traceroute to run (currently only mda).")
+}
 
 func main() {
 	defer cancel()
@@ -65,13 +72,6 @@ func main() {
 		}
 	}()
 
-	// There is a race condition in scamper when it creates its
-	// PRIVSEP_DIR (by default: /var/empty) if it doesn't exist.
-	// The following call is a workaround to make sure PRIVSEP_DIR
-	// already exists before running actual traceroutes which can
-	// happen concurrently.
-	exec.Command(*scamperBin, "-I", "trace -P icmp-paris 127.0.0.1", "-o-", "-O", "json").Run()
-
 	// The triggertrace package needs the following:
 	//   - A traceroute tool for running traceroutes.
 	//   - A traceroute cache to keep traceroute results.
@@ -82,12 +82,12 @@ func main() {
 		Binary:           *scamperBin,
 		OutputPath:       *tracerouteOutput,
 		Timeout:          *scamperTimeout,
-		TraceType:        *scamperTraceType,
+		TraceType:        scamperTraceType.Value,
 		TracelbPTR:       *scamperTracelbPTR,
 		TracelbWaitProbe: *scamperTracelbW,
 	}
 	if err := scamper.Validate(); err != nil {
-		logFatal(err)
+		logFatal(fmt.Errorf("%v: %w", errScamper, err))
 	}
 	// The traceroute cache.
 	// TODO(SaiedKazemi): The name ipcache (in its various forms)
@@ -99,7 +99,7 @@ func main() {
 		ScanPeriod:   *ipcScanPeriod,
 	}
 	// The traceroute parser.
-	newParser, err := parser.New(*scamperTraceType)
+	newParser, err := parser.New(scamperTraceType.Value)
 	if err != nil {
 		logFatal(err)
 	}

--- a/ipcache/ipcache_test.go
+++ b/ipcache/ipcache_test.go
@@ -19,8 +19,8 @@ func init() {
 }
 
 type fakeTracer struct {
-	nTrace                int
-	nTraceFromCachedTrace int
+	nTrace       int
+	nCachedTrace int
 }
 
 func (ft *fakeTracer) Trace(remoteIP, cookie, uuid string, t time.Time) ([]byte, error) {
@@ -28,8 +28,8 @@ func (ft *fakeTracer) Trace(remoteIP, cookie, uuid string, t time.Time) ([]byte,
 	return []byte("fake traceroute data to " + remoteIP), nil
 }
 
-func (ft *fakeTracer) TraceFromCachedTrace(cookie, uuid string, t time.Time, cachedTest []byte) error {
-	ft.nTraceFromCachedTrace++
+func (ft *fakeTracer) CachedTrace(cookie, uuid string, t time.Time, cachedTest []byte) error {
+	ft.nCachedTrace++
 	return nil
 }
 
@@ -49,13 +49,13 @@ func TestNew(t *testing.T) {
 
 func TestFetchTrace(t *testing.T) {
 	tests := []struct {
-		remoteIP                      string
-		cookie                        string
-		wantErr                       bool
-		wantData                      string
-		wantTraceCalls                int
-		wantTraceFromCachedTraceCalls int
-		wantEntries                   int
+		remoteIP             string
+		cookie               string
+		wantErr              bool
+		wantData             string
+		wantTraceCalls       int
+		wantCachedTraceCalls int
+		wantEntries          int
 	}{
 		{"1.1.1.1", "", true, "", 0, 0, 0},
 		{"1.1.1.1", "10f3d", false, "fake traceroute data to 1.1.1.1", 1, 0, 1},
@@ -93,8 +93,8 @@ func TestFetchTrace(t *testing.T) {
 		if gotCalls := tracer.nTrace; gotCalls != test.wantTraceCalls {
 			t.Errorf("got %d calls to Trace(), want %d", gotCalls, test.wantTraceCalls)
 		}
-		if gotCalls := tracer.nTraceFromCachedTrace; gotCalls != test.wantTraceFromCachedTraceCalls {
-			t.Errorf("got %d calls to TraceFromCachedTrace(), want %d", gotCalls, test.wantTraceFromCachedTraceCalls)
+		if gotCalls := tracer.nCachedTrace; gotCalls != test.wantCachedTraceCalls {
+			t.Errorf("got %d calls to CachedTrace(), want %d", gotCalls, test.wantCachedTraceCalls)
 		}
 		if gotEntries := ipCache.NumEntries(); gotEntries != test.wantEntries {
 			t.Errorf("got %d entries in IP cache, want %d", gotEntries, test.wantEntries)
@@ -132,7 +132,7 @@ func (pt *pausingTracer) Trace(remoteIP, cookie, uuid string, t time.Time) ([]by
 	return []byte("fake traceroute data to " + remoteIP), nil
 }
 
-func (pt *pausingTracer) TraceFromCachedTrace(cookie, uuid string, t time.Time, cachedTest []byte) error {
+func (pt *pausingTracer) CachedTrace(cookie, uuid string, t time.Time, cachedTest []byte) error {
 	randomDelay()
 	atomic.AddInt64(&pt.successes, 1)
 	return nil

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,0 +1,67 @@
+// Package parser handles parsing of scamper output in JSONL format.
+package parser
+
+import (
+	//"bytes"
+	"errors"
+	"fmt"
+	"time"
+)
+
+var (
+	errTracerouteType = errors.New("unknown traceroute type")
+	errTracerouteFile = errors.New("invalid traceroute file")
+	errMetadata       = errors.New("invalid metadata")
+	errMetadataUUID   = errors.New("invalid UUID (empty)")
+	errCycleStart     = errors.New("invalid cycle-start")
+	errCycleStartType = errors.New("invalid cycle-start type")
+	errTraceType      = errors.New("invalid trace type")
+	errTracelbLine    = errors.New("invalid tracelb line")
+	errCycleStop      = errors.New("invalid cycle-stop")
+	errCycleStopType  = errors.New("invalid cycle-stop type")
+)
+
+// TS contains a unix epoch timestamp.
+type TS struct {
+	Sec  int64 `json:"sec"`
+	Usec int64 `json:"usec"`
+}
+
+// CyclestartLine contains the information about the scamper "cyclestart"
+type CyclestartLine struct {
+	Type      string  `json:"type"`
+	ListName  string  `json:"list_name" bigquery:"list_name"`
+	ID        float64 `json:"id"`
+	Hostname  string  `json:"hostname"`
+	StartTime float64 `json:"start_time" bigquery:"start_time"`
+}
+
+// CyclestopLine contains the ending details from the scamper tool.  ID,
+// ListName, hostname seem to match CyclestartLine
+type CyclestopLine struct {
+	Type     string  `json:"type"`
+	ListName string  `json:"list_name" bigquery:"list_name"`
+	ID       float64 `json:"id"`
+	Hostname string  `json:"hostname"`
+	StopTime float64 `json:"stop_time" bigquery:"stop_time"`
+}
+
+// ParsedData defines the interface for parsed traceroute data.
+type ParsedData interface {
+	StartTime() time.Time
+	ExtractHops() []string
+}
+
+// TracerouteParser defines the interface for raw traceroute data.
+type TracerouteParser interface {
+	ParseRawData(rawData []byte) (ParsedData, error)
+}
+
+// New returns a new traceroute parser correspondong to the traceroute type.
+func New(traceType string) (TracerouteParser, error) {
+	switch traceType {
+	case "mda":
+		return &scamper1Parser{}, nil
+	}
+	return nil, fmt.Errorf("%s: %v", traceType, errTracerouteType)
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -2,7 +2,6 @@
 package parser
 
 import (
-	//"bytes"
 	"errors"
 	"fmt"
 	"time"
@@ -27,22 +26,22 @@ type TS struct {
 	Usec int64 `json:"usec"`
 }
 
-// CyclestartLine contains the information about the scamper "cyclestart"
+// CyclestartLine contains the information about the scamper "cyclestart".
 type CyclestartLine struct {
-	Type      string  `json:"type"`
+	Type      string  `json:"type" bigquery:"type"`
 	ListName  string  `json:"list_name" bigquery:"list_name"`
-	ID        float64 `json:"id"`
-	Hostname  string  `json:"hostname"`
+	ID        float64 `json:"id" bigquery:"id"`
+	Hostname  string  `json:"hostname" bigquery:"hostname"`
 	StartTime float64 `json:"start_time" bigquery:"start_time"`
 }
 
-// CyclestopLine contains the ending details from the scamper tool.  ID,
-// ListName, hostname seem to match CyclestartLine
+// CyclestopLine contains the ending details from the scamper tool.
+// ListName, ID, and Hostname seem to match CyclestartLine.
 type CyclestopLine struct {
-	Type     string  `json:"type"`
+	Type     string  `json:"type" bigquery:"type"`
 	ListName string  `json:"list_name" bigquery:"list_name"`
-	ID       float64 `json:"id"`
-	Hostname string  `json:"hostname"`
+	ID       float64 `json:"id" bigquery:"id"`
+	Hostname string  `json:"hostname" bigquery:"hostname"`
 	StopTime float64 `json:"stop_time" bigquery:"stop_time"`
 }
 
@@ -63,5 +62,5 @@ func New(traceType string) (TracerouteParser, error) {
 	case "mda":
 		return &scamper1Parser{}, nil
 	}
-	return nil, fmt.Errorf("%s: %v", traceType, errTracerouteType)
+	return nil, fmt.Errorf("%q: %v", traceType, errTracerouteType)
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,0 +1,42 @@
+package parser
+
+import "errors"
+
+func badErr(gotErr, wantErr error) bool {
+	bad := false
+	if gotErr == nil {
+		if wantErr != nil {
+			bad = true
+		}
+	} else if !errors.Is(gotErr, wantErr) {
+		bad = true
+	}
+	return bad
+}
+
+// isEqual returns true if all of the elements in s1 exist in s2.
+func isEqual(s1, s2 []string) bool {
+	if s1 == nil && s2 == nil {
+		return true
+	}
+	if (s1 == nil && s2 != nil) || (s1 != nil && s2 == nil) {
+		return false
+	}
+	if len(s1) != len(s2) {
+		return false
+	}
+	diff := make(map[string]int, len(s1))
+	for _, s := range s1 {
+		diff[s]++
+	}
+	for _, s := range s2 {
+		if _, ok := diff[s]; !ok {
+			return false
+		}
+		diff[s]--
+		if diff[s] == 0 {
+			delete(diff, s)
+		}
+	}
+	return len(diff) == 0
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,17 +1,53 @@
 package parser
 
-import "errors"
+import (
+	"log"
+	"strings"
+	"testing"
+	"time"
+)
+
+func init() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		traceType string
+		wantErr   error
+	}{
+		{"mda", nil},
+		{"", errTracerouteType},
+		{"bad", errTracerouteType},
+	}
+	for _, test := range tests {
+		_, gotErr := New(test.traceType)
+		if badErr(gotErr, test.wantErr) {
+			t.Fatalf("New() = %v, want %v", gotErr, test.wantErr)
+		}
+	}
+}
+
+func TestStartTime(t *testing.T) {
+	s1 := Scamper1{
+		CycleStart: CyclestartLine{
+			StartTime: 1566691268,
+		},
+	}
+	want := time.Unix(1566691268, 0).UTC()
+	if got := s1.StartTime(); got != want {
+		t.Fatalf("StartTime() = %v, want %v", got, want)
+	}
+}
 
 func badErr(gotErr, wantErr error) bool {
-	bad := false
 	if gotErr == nil {
-		if wantErr != nil {
-			bad = true
-		}
-	} else if !errors.Is(gotErr, wantErr) {
-		bad = true
+		return wantErr != nil
 	}
-	return bad
+	if strings.Contains(gotErr.Error(), wantErr.Error()) {
+		return false
+	}
+	return true
 }
 
 // isEqual returns true if all of the elements in s1 exist in s2.

--- a/parser/scamper1_test.go
+++ b/parser/scamper1_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"errors"
 	"io/ioutil"
 	"log"
 	"path/filepath"
@@ -13,20 +12,20 @@ func init() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 }
 
-func TestParser(t *testing.T) {
+func TestScamper1Parser(t *testing.T) {
 	tests := []struct {
 		file     string
 		wantErr  error
 		wantHops []string
 	}{
-		{"invalid-num-lines", errTraceroute, nil},
-		{"invalid-last-line", errTraceroute, nil},
+		{"invalid-num-lines", errTracerouteFile, nil},
+		{"invalid-last-line", errTracerouteFile, nil},
 		{"invalid-metadata", errMetadata, nil},
 		{"invalid-metadata-uuid", errMetadataUUID, nil},
 		{"invalid-cycle-start", errCycleStart, nil},
 		{"invalid-cycle-start-type", errCycleStartType, nil},
-		{"invalid-tracelb", errTracelb, nil},
-		{"invalid-tracelb-type", errTracelbType, nil},
+		{"invalid-tracelb", errTracelbLine, nil},
+		{"invalid-tracelb-type", errTraceType, nil},
 		{"invalid-cycle-stop", errCycleStop, nil},
 		{"invalid-cycle-stop-type", errCycleStopType, nil},
 		{"invalid-tracelb-links", nil, nil},
@@ -49,10 +48,10 @@ func TestParser(t *testing.T) {
 			t.Fatalf(err.Error())
 		}
 
-		// Extract the start_time from the cycle-start line.
-		scamperOutput, gotErr := ParseTraceroute(content)
+		// Extract start_time from the cycle-start line.
+		scamperOutput, gotErr := (&scamper1Parser{}).ParseRawData(content)
 		if badErr(gotErr, test.wantErr) {
-			t.Fatalf("ParseTraceroute(): %v, want %v", gotErr, test.wantErr)
+			t.Fatalf("ParseRawData(): %v, want %v", gotErr, test.wantErr)
 		}
 
 		// If the test traceroute output file isn't valid,
@@ -62,48 +61,9 @@ func TestParser(t *testing.T) {
 		}
 
 		// Extract the hops.
-		gotHops := ExtractHops(&scamperOutput.Tracelb)
+		gotHops := scamperOutput.ExtractHops()
 		if !isEqual(gotHops, test.wantHops) {
 			t.Fatalf("got %+v, want %+v", gotHops, test.wantHops)
 		}
 	}
-}
-
-func badErr(gotErr, wantErr error) bool {
-	bad := false
-	if gotErr == nil {
-		if wantErr != nil {
-			bad = true
-		}
-	} else if !errors.Is(gotErr, wantErr) {
-		bad = true
-	}
-	return bad
-}
-
-// isEqual returns true if all of the elements in s1 exist in s2.
-func isEqual(s1, s2 []string) bool {
-	if s1 == nil && s2 == nil {
-		return true
-	}
-	if (s1 == nil && s2 != nil) || (s1 != nil && s2 == nil) {
-		return false
-	}
-	if len(s1) != len(s2) {
-		return false
-	}
-	diff := make(map[string]int, len(s1))
-	for _, s := range s1 {
-		diff[s]++
-	}
-	for _, s := range s2 {
-		if _, ok := diff[s]; !ok {
-			return false
-		}
-		diff[s]--
-		if diff[s] == 0 {
-			delete(diff, s)
-		}
-	}
-	return len(diff) == 0
 }

--- a/parser/scamper1_test.go
+++ b/parser/scamper1_test.go
@@ -2,15 +2,10 @@ package parser
 
 import (
 	"io/ioutil"
-	"log"
 	"path/filepath"
 	"strings"
 	"testing"
 )
-
-func init() {
-	log.SetFlags(log.LstdFlags | log.Lshortfile)
-}
 
 func TestScamper1Parser(t *testing.T) {
 	tests := []struct {

--- a/tracer/scamper.go
+++ b/tracer/scamper.go
@@ -33,10 +33,11 @@ func (s *Scamper) Validate() error {
 	if err != nil {
 		return fmt.Errorf("failed to stat scamper binary (error: %v)", err)
 	}
-	if fileInfo.IsDir() {
-		return fmt.Errorf("scamper binary is a directory")
+	fileMode := fileInfo.Mode()
+	if !fileMode.IsRegular() {
+		return fmt.Errorf("scamper binary is not a regular file")
 	}
-	if fileInfo.Mode()&0100 == 0 {
+	if fileMode&0100 == 0 {
 		return fmt.Errorf("scamper binary is not executable by owner")
 	}
 

--- a/tracer/scamper.go
+++ b/tracer/scamper.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"strconv"
@@ -18,9 +19,27 @@ import (
 type Scamper struct {
 	Binary           string
 	OutputPath       string
-	ScamperTimeout   time.Duration
+	Timeout          time.Duration
+	TraceType        string
 	TracelbPTR       bool
 	TracelbWaitProbe int
+	noArgs           bool // used only for package testing
+}
+
+// Validate validates the traceroute type, returning nil for valid types
+// and error for invalid types.
+func (s *Scamper) Validate() error {
+	switch s.TraceType {
+	case "MDA":
+		s.TraceType = "mda"
+		fallthrough
+	case "mda":
+		if s.TracelbWaitProbe < 15 || s.TracelbWaitProbe > 200 {
+			return fmt.Errorf("%d: invalid tracelb wait probe", s.TracelbWaitProbe)
+		}
+		return nil
+	}
+	return fmt.Errorf("%s: invalid traceroute type", s.TraceType)
 }
 
 // Trace starts a new scamper process running the paris-traceroute algorithm to
@@ -32,8 +51,8 @@ func (s *Scamper) Trace(remoteIP, cookie, uuid string, t time.Time) (out []byte,
 	return s.trace(remoteIP, cookie, uuid, t)
 }
 
-// TraceFromCachedTrace creates test from cached trace.
-func (s *Scamper) TraceFromCachedTrace(uuid, cookie string, t time.Time, cachedTest []byte) error {
+// CachedTrace creates a traceroute from the traceroute cache.
+func (s *Scamper) CachedTrace(uuid, cookie string, t time.Time, cachedTrace []byte) error {
 	filename, err := generateFilename(s.OutputPath, cookie, t)
 	if err != nil {
 		log.Printf("failed to generate filename (error: %v)\n", err)
@@ -41,26 +60,26 @@ func (s *Scamper) TraceFromCachedTrace(uuid, cookie string, t time.Time, cachedT
 		return err
 	}
 
-	// Remove the first line of cachedTest.
-	split := bytes.Index(cachedTest, []byte{'\n'})
-	if split <= 0 || split == len(cachedTest) {
-		log.Printf("failed to split cached test (split: %v)\n", split)
+	// Remove the first line of cachedTrace.
+	split := bytes.Index(cachedTrace, []byte{'\n'})
+	if split <= 0 || split == len(cachedTrace) {
+		log.Printf("failed to split cached traceroute (split: %v)\n", split)
 		tracerCacheErrors.WithLabelValues("scamper", "badcache").Inc()
-		return errors.New("invalid cached test")
+		return errors.New("invalid cached traceroute")
 	}
 
 	// Create and add the first line to the test results.
-	newTest := append(createMetaline(uuid, true, extractUUID(cachedTest[:split])), cachedTest[split+1:]...)
+	newTest := append(createMetaline(uuid, true, extractUUID(cachedTrace[:split])), cachedTrace[split+1:]...)
 	return ioutil.WriteFile(filename, []byte(newTest), 0666)
 }
 
-// DontTrace is called when a previous trace that we were waiting for
+// DontTrace is called when a previous traceroute that we were waiting for
 // fails. It increments a counter that tracks the number of these failures.
 func (*Scamper) DontTrace() {
 	tracesNotPerformed.WithLabelValues("scamper").Inc()
 }
 
-// trace a single connection using scamper as a standalone binary.
+// trace runs a traceroute using scamper as a standalone binary.
 func (s *Scamper) trace(remoteIP, cookie, uuid string, t time.Time) ([]byte, error) {
 	// Make sure a directory path based on the current date exists,
 	// generate a filename to save in that directory, and create
@@ -69,21 +88,41 @@ func (s *Scamper) trace(remoteIP, cookie, uuid string, t time.Time) ([]byte, err
 	if err != nil {
 		return nil, err
 	}
-	// Create a context and initialize command execution variables.
-	ctx, cancel := context.WithTimeout(context.Background(), s.ScamperTimeout)
-	defer cancel()
-	tracelbCmd := []string{"tracelb", "-P", "icmp-echo", "-q", "3", "-W", strconv.Itoa(s.TracelbWaitProbe)}
-	if s.TracelbPTR {
-		tracelbCmd = append(tracelbCmd, []string{"-O", "ptr"}...)
+
+	// Initialize command execution variables.
+	var traceCmd string
+	switch s.TraceType {
+	case "mda":
+		var ptr string
+		if s.TracelbPTR {
+			ptr = "-O ptr"
+		} else {
+			ptr = ""
+		}
+		traceCmd = fmt.Sprintf("tracelb -P icmp-echo -q 3 -W %s %s %s", strconv.Itoa(s.TracelbWaitProbe), ptr, remoteIP)
+	default:
+		return nil, fmt.Errorf("%s: invalid traceroute type", s.TraceType)
 	}
-	tracelbCmd = append(tracelbCmd, remoteIP)
-	cmd := shx.Exec(s.Binary, "-I", strings.Join(tracelbCmd, " "), "-o-", "-O", "json")
+	// When testing this package, instead of scamper, a different
+	// command like echo, yes, and false is used which does not
+	// need the scamper command line arguments and can actually
+	// fail because of them.
+	var cmd []string
+	if s.noArgs {
+		cmd = []string{s.Binary}
+	} else {
+		cmd = []string{s.Binary, "-o-", "-O", "json", "-I", traceCmd}
+	}
+
+	// Create a context, run a traceroute, and write the output to file.
+	ctx, cancel := context.WithTimeout(context.Background(), s.Timeout)
+	defer cancel()
 	return traceAndWrite(ctx, "scamper", filename, cmd, uuid)
 }
 
-// traceAndWrite runs a traceroute and write the result.
-func traceAndWrite(ctx context.Context, label string, filename string, cmd shx.Job, uuid string) ([]byte, error) {
-	data, err := runTrace(ctx, label, cmd)
+// traceAndWrite runs a traceroute and writes the result.
+func traceAndWrite(ctx context.Context, label string, filename string, cmd []string, uuid string) ([]byte, error) {
+	data, err := runCmd(ctx, label, cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -97,38 +136,34 @@ func traceAndWrite(ctx context.Context, label string, filename string, cmd shx.J
 	return buff.Bytes(), ioutil.WriteFile(filename, buff.Bytes(), 0444)
 }
 
-// runTrace executes a trace command and returns the data.
-func runTrace(ctx context.Context, label string, cmd shx.Job) ([]byte, error) {
-	var desc shx.Description
+// runCmd runs the given command and returns its output.
+func runCmd(ctx context.Context, label string, cmd []string) ([]byte, error) {
 	deadline, _ := ctx.Deadline()
 	timeout := time.Until(deadline)
-	cmd.Describe(&desc)
-	log.Printf("Trace started: %s\n", desc.String())
-
-	// Add buffer write at end of cmd.
+	job := shx.Exec(cmd[0], cmd[1:]...)
 	buff := bytes.Buffer{}
-	fullCmd := shx.Pipe(cmd, shx.Write(&buff))
+	fullCmd := shx.Pipe(job, shx.Write(&buff))
 
+	log.Printf("context %p: command %s started\n", ctx, strings.Join(cmd, " "))
 	start := time.Now()
 	err := fullCmd.Run(ctx, shx.New())
 	latency := time.Since(start).Seconds()
-	log.Printf("Trace returned in %v seconds", latency)
+	log.Printf("context %p: command finished in %v seconds", ctx, latency)
 	tracesPerformed.WithLabelValues(label).Inc()
 	if err != nil {
-		// TODO change to use a label within general trace counter.
+		// TODO change to use a label within general traceroute counter.
 		// possibly just use the latency histogram?
 		crashedTraces.WithLabelValues(label).Inc()
-
 		traceTimeHistogram.WithLabelValues("error").Observe(latency)
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			log.Printf("Trace timed out after %v\n", timeout)
+			log.Printf("context %p: command timed out after %v\n", ctx, timeout)
 		} else {
-			log.Printf("Trace failed in context %p (error: %v)\n", ctx, err)
+			log.Printf("context %p: command failed (error: %v)\n", ctx, err)
 		}
 		return buff.Bytes(), err
 	}
 
-	log.Printf("Trace succeeded in context %p\n", ctx)
+	log.Printf("Command succeeded in context %p\n", ctx)
 	traceTimeHistogram.WithLabelValues("success").Observe(latency)
 	return buff.Bytes(), nil
 }

--- a/tracer/scamper.go
+++ b/tracer/scamper.go
@@ -29,16 +29,19 @@ type Scamper struct {
 // Validate validates scamper configuration, returning nil for valid
 // and an error for invalid configurations.
 func (s *Scamper) Validate() error {
-	if fileInfo, err := os.Stat(s.Binary); err != nil {
+	fileInfo, err := os.Stat(s.Binary)
+	if err != nil {
 		return fmt.Errorf("failed to stat scamper binary (error: %v)", err)
-	} else if fileInfo.IsDir() {
+	}
+	if fileInfo.IsDir() {
 		return fmt.Errorf("scamper binary is a directory")
 	}
+	if fileInfo.Mode()&0100 == 0 {
+		return fmt.Errorf("scamper binary is not executable by owner")
+	}
 
+	// Regular traceroutes will soon be added an another valid type.
 	switch s.TraceType {
-	case "MDA":
-		s.TraceType = "mda"
-		fallthrough
 	case "mda": // uses paris-traceroute algorithm
 		if s.TracelbWaitProbe < 15 || s.TracelbWaitProbe > 200 {
 			return fmt.Errorf("%d: invalid tracelb wait probe value", s.TracelbWaitProbe)

--- a/tracer/scamper_test.go
+++ b/tracer/scamper_test.go
@@ -2,13 +2,10 @@ package tracer
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 	"log"
 	"os"
-
 	"strings"
 	"testing"
 	"time"
@@ -24,43 +21,61 @@ func init() {
 
 func TestTrace(t *testing.T) {
 	dir, err := ioutil.TempDir("", "TestScamper")
-	rtx.Must(err, "failed to create tempdir")
-	s := &Scamper{
-		OutputPath:     dir,
-		Binary:         "echo",
-		ScamperTimeout: time.Duration(time.Hour),
-		TracelbPTR:     true,
-	}
-	cookie := "12AB"
-	now := time.Date(2003, 11, 9, 15, 55, 59, 0, time.UTC)
-	out, err := s.Trace("10.1.1.1", cookie, "", now)
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantOut := `{"UUID":"` + `","TracerouteCallerVersion":"` + prometheusx.GitShortCommit + `","CachedResult":false,"CachedUUID":""}
--I tracelb -P icmp-echo -q 3 -W 0 -O ptr 10.1.1.1 -o- -O json
-`
-	gotOut := string(out)
-	if strings.TrimSpace(gotOut) != strings.TrimSpace(wantOut) {
-		t.Errorf("Trace() = %q, want %q", strings.TrimSpace(gotOut), strings.TrimSpace(wantOut))
-	}
-	contents, err := ioutil.ReadFile(dir + "/2003/11/09/20031109T155559Z_" + prefix.UnsafeString() + "_00000000000012AB.jsonl")
-	rtx.Must(err, "failed to read file")
-	if string(contents) != gotOut {
-		t.Errorf("contents = %q, want %q", string(contents), gotOut)
-	}
+	cookie := "12AB"
+	now := time.Date(2003, 11, 9, 15, 55, 59, 0, time.UTC)
+	path := dir + "/2003/11/09/20031109T155559Z_" + prefix.UnsafeString() + "_00000000000012AB.jsonl"
 
-	s.Binary = "false"
-	_, err = s.Trace("10.1.1.1", cookie, "", now)
-	if err == nil {
-		t.Error("Trace() = nil, want error")
+	tests := []struct {
+		binary     string
+		traceType  string
+		noArgs     bool
+		shouldFail bool
+		want       string
+	}{
+		{"false", "mda", true, true, ""},
+		{"yes", "mda", true, true, ""},
+		{"echo", "mda", false, false, `{"UUID":"","TracerouteCallerVersion":"` + prometheusx.GitShortCommit + `","CachedTrace":false,"CachedUUID":""}
+-o- -O json -I tracelb -P icmp-echo -q 3 -W 39 -O ptr 10.1.1.1`},
 	}
-
-	s.Binary = "yes"
-	s.ScamperTimeout = time.Nanosecond
-	_, err = s.Trace("10.1.1.1", cookie, "", now)
-	if err == nil {
-		t.Errorf("Trace() = %v, want nil", err)
+	for _, test := range tests {
+		os.RemoveAll(path)
+		s := &Scamper{
+			OutputPath:       dir,
+			Timeout:          1 * time.Second,
+			TracelbPTR:       true,
+			TracelbWaitProbe: 39,
+		}
+		s.Binary = test.binary
+		s.TraceType = test.traceType
+		s.noArgs = test.noArgs
+		// Run a traceroute.
+		out, err := s.Trace("10.1.1.1", cookie, "", now)
+		if test.shouldFail {
+			if err == nil {
+				t.Error("Trace() = nil, want error")
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("Trace() = %v, want nil", err)
+			continue
+		}
+		got := string(out)
+		if strings.TrimSpace(got) != strings.TrimSpace(test.want) {
+			t.Errorf("Trace() = %q, want %q", strings.TrimSpace(got), strings.TrimSpace(test.want))
+		}
+		// Make sure that the output was correctly written to file.
+		out, err = ioutil.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got = string(out)
+		if strings.TrimSpace(got) != strings.TrimSpace(test.want) {
+			t.Errorf("ReadFile(%v) = %q, want %q", path, got, test.want)
+		}
 	}
 }
 
@@ -76,9 +91,12 @@ func TestTraceWritesMeta(t *testing.T) {
 	hostname = "testhostname"
 
 	s := &Scamper{
-		Binary:         "echo",
-		OutputPath:     tempdir,
-		ScamperTimeout: 1 * time.Minute,
+		Binary:           "echo",
+		OutputPath:       tempdir,
+		Timeout:          1 * time.Minute,
+		TraceType:        "mda",
+		TracelbPTR:       true,
+		TracelbWaitProbe: 39,
 	}
 	faketime := time.Date(2019, time.April, 1, 3, 45, 51, 0, time.UTC)
 	prometheusx.GitShortCommit = "Fake Version"
@@ -106,33 +124,7 @@ func TestTraceWritesMeta(t *testing.T) {
 	}
 }
 
-func TestTraceTimeout(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "TestTimeoutTrace")
-	rtx.Must(err, "failed to create tempdir")
-	defer os.RemoveAll(tempdir)
-
-	s := &Scamper{
-		Binary:         "yes",
-		OutputPath:     tempdir,
-		ScamperTimeout: 1 * time.Nanosecond,
-	}
-
-	defer func() {
-		r := recover()
-		if r != nil {
-			t.Errorf("recover() = %v, want nil (error: %v)", r, err)
-		}
-	}()
-
-	faketime := time.Date(2019, time.April, 1, 3, 45, 51, 0, time.UTC)
-	prometheusx.GitShortCommit = "Fake Version"
-	_, err = s.Trace("1.2.3.4", "1", "", faketime)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Errorf("Trace() = %v, want %v", err, context.DeadlineExceeded)
-	}
-}
-
-func TestTraceFromCachedTrace(t *testing.T) {
+func TestCachedTrace(t *testing.T) {
 	tempdir, err := ioutil.TempDir("", "TestCachedTrace")
 	rtx.Must(err, "failed to create tempdir")
 	defer os.RemoveAll(tempdir)
@@ -144,25 +136,28 @@ func TestTraceFromCachedTrace(t *testing.T) {
 	hostname = "testhostname"
 
 	s := &Scamper{
-		Binary:         "echo",
-		OutputPath:     tempdir,
-		ScamperTimeout: 1 * time.Minute,
+		Binary:           "echo",
+		OutputPath:       tempdir,
+		Timeout:          1 * time.Minute,
+		TraceType:        "mda",
+		TracelbPTR:       true,
+		TracelbWaitProbe: 39,
 	}
 
 	faketime := time.Date(2019, time.April, 1, 3, 45, 51, 0, time.UTC)
 	prometheusx.GitShortCommit = "Fake Version"
-	cachedTest := []byte(`{"UUID": "ndt-plh7v_1566050090_000000000004D64D"}
+	cachedTrace := []byte(`{"UUID": "ndt-plh7v_1566050090_000000000004D64D"}
 	{"type":"cycle-start", "list_name":"/tmp/scamperctrl:51811", "id":1, "hostname":"ndt-plh7v", "start_time":1566691298}
 	{"type":"tracelb", "version":"0.1", "userid":0, "method":"icmp-echo", "src":"::ffff:180.87.97.101", "dst":"::ffff:1.47.236.62", "start":{"sec":1566691298, "usec":476221, "ftime":"2019-08-25 00:01:38"}, "probe_size":60, "firsthop":1, "attempts":3, "confidence":95, "tos":0, "gaplimit":3, "wait_timeout":5, "wait_probe":250, "probec":0, "probec_max":3000, "nodec":0, "linkc":0}
 	{"type":"cycle-stop", "list_name":"/tmp/scamperctrl:51811", "id":1, "hostname":"ndt-plh7v", "stop_time":1566691298}`)
 
-	_ = s.TraceFromCachedTrace("ndt-plh7v_1566050090_000000000004D64D", "1", faketime, []byte("Broken cached test"))
+	_ = s.CachedTrace("ndt-plh7v_1566050090_000000000004D64D", "1", faketime, []byte("Broken cached traceroute"))
 	_, errInvalidTest := ioutil.ReadFile(tempdir + "/2019/04/01/20190401T034551Z_" + prefix.UnsafeString() + "_0000000000000001.jsonl")
 	if errInvalidTest == nil {
-		t.Error("TraceFromCachedTrace() = nil, want error")
+		t.Error("CachedTrace() = nil, want error")
 	}
 
-	_ = s.TraceFromCachedTrace("ndt-plh7v_1566050090_000000000004D64D", "1", faketime, cachedTest)
+	_ = s.CachedTrace("ndt-plh7v_1566050090_000000000004D64D", "1", faketime, cachedTrace)
 	// Unmarshal the first line of the output file.
 	b, err := ioutil.ReadFile(tempdir + "/2019/04/01/20190401T034551Z_" + prefix.UnsafeString() + "_0000000000000001.jsonl")
 	rtx.Must(err, "failed to read file")
@@ -181,8 +176,8 @@ func TestTraceFromCachedTrace(t *testing.T) {
 	if m.TracerouteCallerVersion != "Fake Version" {
 		t.Errorf("got traceroute caller version %q, want %q", m.TracerouteCallerVersion, "Fake Version")
 	}
-	if m.CachedResult != true {
-		t.Errorf("got cached result %v, want true", m.CachedResult)
+	if m.CachedTrace != true {
+		t.Errorf("got cached result %v, want true", m.CachedTrace)
 	}
 	wantUUID = "ndt-plh7v_1566050090_000000000004D64D"
 	if m.CachedUUID != "ndt-plh7v_1566050090_000000000004D64D" {
@@ -191,8 +186,8 @@ func TestTraceFromCachedTrace(t *testing.T) {
 
 	// Now test an error condition.
 	s.OutputPath = "/dev/null"
-	if s.TraceFromCachedTrace("ndt-plh7v_1566050090_000000000004D64D", "1", faketime, cachedTest) == nil {
-		t.Error("TraceFromCachedTrace() = nil, want error")
+	if s.CachedTrace("ndt-plh7v_1566050090_000000000004D64D", "1", faketime, cachedTrace) == nil {
+		t.Error("CachedTrace() = nil, want error")
 	}
 }
 
@@ -218,7 +213,7 @@ func TestDontTrace(t *testing.T) {
 func TestCreateMetaline(t *testing.T) {
 	prometheusx.GitShortCommit = "Fake Version"
 	gotMeta := createMetaline("0000000000000ABC", true, "00EF")
-	wantMeta := []byte("0000000000000ABC\",\"TracerouteCallerVersion\":\"Fake Version\",\"CachedResult\":true,\"CachedUUID\":\"00EF\"")
+	wantMeta := []byte("0000000000000ABC\",\"TracerouteCallerVersion\":\"Fake Version\",\"CachedTrace\":true,\"CachedUUID\":\"00EF\"")
 	if !bytes.Contains(gotMeta, wantMeta) {
 		t.Errorf("gotMeta %q does not contain wantMeta %q", gotMeta, wantMeta)
 	}
@@ -231,7 +226,7 @@ func TestInvalidCookie(t *testing.T) {
 	if _, err := s.Trace("10.1.1.1", "an invalid cookie", "", time.Now()); err == nil {
 		t.Error("Trace() = nil, want error")
 	}
-	if err := s.TraceFromCachedTrace("", "an invalid cookie", time.Now(), nil); err == nil {
-		t.Error("TraceFromCachedTrace() = nil, want error")
+	if err := s.CachedTrace("", "an invalid cookie", time.Now(), nil); err == nil {
+		t.Error("CachedTrace() = nil, want error")
 	}
 }

--- a/tracer/scamper_test.go
+++ b/tracer/scamper_test.go
@@ -27,10 +27,11 @@ func TestValidate(t *testing.T) {
 		shouldFail       bool
 		want             string
 	}{
-		{"/non-existent/path", "mda", 15, true, "failed to stat scamper binary"},
-		{"/", "mda", 15, true, "scamper binary is a directory"},
+		{"testdata/non-existent", "mda", 15, true, "failed to stat scamper binary"},
+		{"testdata", "mda", 15, true, "scamper binary is a directory"},
+		{"testdata/non-executable", "mda", 15, true, "scamper binary is not executable by owner"},
 		{"/bin/echo", "bad", 15, true, "invalid traceroute type"},
-		{"/bin/echo", "MDA", 14, true, "invalid tracelb wait probe value"},
+		{"/bin/echo", "mda", 14, true, "invalid tracelb wait probe value"},
 		{"/bin/echo", "mda", 201, true, "invalid tracelb wait probe value"},
 		{"/bin/echo", "mda", 25, false, ""},
 	}

--- a/tracer/scamper_test.go
+++ b/tracer/scamper_test.go
@@ -28,7 +28,7 @@ func TestValidate(t *testing.T) {
 		want             string
 	}{
 		{"testdata/non-existent", "mda", 15, true, "failed to stat scamper binary"},
-		{"testdata", "mda", 15, true, "scamper binary is a directory"},
+		{"testdata", "mda", 15, true, "scamper binary is not a regular file"},
 		{"testdata/non-executable", "mda", 15, true, "scamper binary is not executable by owner"},
 		{"/bin/echo", "bad", 15, true, "invalid traceroute type"},
 		{"/bin/echo", "mda", 14, true, "invalid tracelb wait probe value"},

--- a/tracer/testdata/fail
+++ b/tracer/testdata/fail
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "forced failure"
+exit 1

--- a/tracer/testdata/loop
+++ b/tracer/testdata/loop
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+while :; do
+	sleep 1
+done

--- a/tracer/testdata/non-executable
+++ b/tracer/testdata/non-executable
@@ -1,0 +1,1 @@
+This is a non-executable file.

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -1,4 +1,4 @@
-// Package tracer takes care of all interactions with the trace tools
+// Package tracer takes care of all interactions with the traceroute tools
 // (currently only scamper).
 package tracer
 
@@ -78,7 +78,7 @@ var (
 type Metadata struct {
 	UUID                    string
 	TracerouteCallerVersion string
-	CachedResult            bool
+	CachedTrace             bool
 	CachedUUID              string
 }
 
@@ -88,28 +88,28 @@ func init() {
 	rtx.Must(err, "failed to call os.Hostname")
 }
 
-// extractUUID retrieves the UUID from a cached line.
+// extractUUID returns the UUID in the metadata line of a traceroute.
 //
 // TODO: Eliminate the need to unmarshal data we marshaled in the first place.
 func extractUUID(metaline []byte) string {
-	var metaResult Metadata
-	err := json.Unmarshal(metaline, &metaResult)
+	var md Metadata
+	err := json.Unmarshal(metaline, &md)
 	if err != nil {
-		log.Println("failed to parse cached results:", string(metaline))
+		log.Println("failed to parse metaline:", string(metaline))
 		return ""
 	}
-	return metaResult.UUID
+	return md.UUID
 }
 
-// createMetaline returns the what the first line of the output jsonl file should
-// be. Parameter isCache indicates whether this meta line is for an original
-// trace test or a cached test, and parameter cachedUUID is the original test if
-// isCache is 1.
+// createMetaline returns what the first line of the .jsonl output file
+// should be. Parameter isCache indicates whether this meta line is for an
+// original traceroute or a cached traceroute, and parameter cachedUUID is
+// the original traceroute if isCache is 1.
 func createMetaline(uuid string, isCache bool, cachedUUID string) []byte {
 	meta := Metadata{
 		UUID:                    uuid,
 		TracerouteCallerVersion: prometheusx.GitShortCommit,
-		CachedResult:            isCache,
+		CachedTrace:             isCache,
 		CachedUUID:              cachedUUID,
 	}
 	metaJSON, _ := json.Marshal(meta)

--- a/triggertrace/triggertrace.go
+++ b/triggertrace/triggertrace.go
@@ -31,11 +31,18 @@ type Destination struct {
 	Cookie   string
 }
 
-// FetchTracer is the interface for obtaining a traceroute result.
-// The implementation can return results from a recent cache in order to
-// avoid running multiple traceroutes to the same destination in short time.
+// FetchTracer is the interface for obtaining a traceroute.  The
+// implementation will return the traceroute from a recent entry in the
+// cache (if it exists) in order to avoid running multiple traceroutes to
+// the same destination in a short time.
 type FetchTracer interface {
 	FetchTrace(remoteIP, cookie string) ([]byte, error)
+}
+
+// ParseTracer is the interface for parsing raw traceroutes obtained
+// from the traceroute tool.
+type ParseTracer interface {
+	ParseRawData(rawData []byte) (parser.ParsedData, error)
 }
 
 // AnnotateAndArchiver is the interface for annotating IP addresses and
@@ -50,15 +57,15 @@ type Handler struct {
 	Destinations     map[string]Destination // key is UUID
 	DestinationsLock sync.Mutex
 	LocalIPs         []*net.IP
-	Traceroutes      FetchTracer
+	IPCache          FetchTracer
+	Parser           ParseTracer
 	HopAnnotator     AnnotateAndArchiver
-	// For testing.
-	done chan struct{}
+	done             chan struct{} // For testing.
 }
 
 // NewHandler returns a new instance of Handler.
-func NewHandler(ctx context.Context, tracer ipcache.Tracer, ipcCfg ipcache.Config, haCfg hopannotation.Config) (*Handler, error) {
-	ipCache, err := ipcache.New(ctx, tracer, ipcCfg)
+func NewHandler(ctx context.Context, tracetool ipcache.Tracer, ipcCfg ipcache.Config, newParser parser.TracerouteParser, haCfg hopannotation.Config) (*Handler, error) {
+	ipCache, err := ipcache.New(ctx, tracetool, ipcCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -72,8 +79,9 @@ func NewHandler(ctx context.Context, tracer ipcache.Tracer, ipcCfg ipcache.Confi
 	}
 	return &Handler{
 		Destinations: make(map[string]Destination),
-		Traceroutes:  ipCache,
 		LocalIPs:     myIPs,
+		IPCache:      ipCache,
+		Parser:       newParser,
 		HopAnnotator: hopCache,
 	}, nil
 }
@@ -128,23 +136,23 @@ func (h *Handler) traceAnnotateAndArchive(ctx context.Context, dest Destination)
 			close(h.done)
 		}
 	}()
-	data, err := h.Traceroutes.FetchTrace(dest.RemoteIP, dest.Cookie)
+	rawData, err := h.IPCache.FetchTrace(dest.RemoteIP, dest.Cookie)
 	if err != nil {
 		log.Printf("failed to run a traceroute to %q (error: %v)\n", dest, err)
 		return
 	}
-	output, err := parser.ParseTraceroute(data)
+	parsedData, err := h.Parser.ParseRawData(rawData)
 	if err != nil {
 		log.Printf("failed to parse traceroute output (error: %v)\n", err)
 		return
 	}
-	hops := parser.ExtractHops(&output.Tracelb)
+	hops := parsedData.ExtractHops()
 	if len(hops) == 0 {
-		log.Printf("failed to extract hops from tracelb %+v\n", output.Tracelb)
+		log.Printf("failed to extract hops from traceroute %+v\n", string(rawData))
 		return
 	}
 
-	traceStartTime := time.Unix(int64(output.CycleStart.StartTime), 0).UTC()
+	traceStartTime := parsedData.StartTime()
 	annotations, allErrs := h.HopAnnotator.Annotate(ctx, hops, traceStartTime)
 	if allErrs != nil {
 		log.Printf("failed to annotate some or all hops (errors: %+v)\n", allErrs)

--- a/triggertrace/triggertrace_test.go
+++ b/triggertrace/triggertrace_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/m-lab/tcp-info/inetdiag"
 	"github.com/m-lab/traceroute-caller/hopannotation"
 	"github.com/m-lab/traceroute-caller/ipcache"
+	"github.com/m-lab/traceroute-caller/parser"
 	"github.com/m-lab/uuid-annotator/annotator"
 )
 
@@ -29,8 +30,8 @@ func init() {
 }
 
 type fakeTracer struct {
-	nTraces                int32
-	nTraceFromCachedTraces int32
+	nTraces       int32
+	nCachedTraces int32
 }
 
 func (ft *fakeTracer) Trace(remoteIP, cookie, uuid string, t time.Time) ([]byte, error) {
@@ -55,9 +56,9 @@ func (ft *fakeTracer) Trace(remoteIP, cookie, uuid string, t time.Time) ([]byte,
 	return content, nil
 }
 
-func (ft *fakeTracer) TraceFromCachedTrace(cookie, uuid string, t time.Time, cachedTest []byte) error {
-	defer func() { atomic.AddInt32(&ft.nTraceFromCachedTraces, 1) }()
-	fmt.Printf("\nTraceFromCachedTrace()\n")
+func (ft *fakeTracer) CachedTrace(cookie, uuid string, t time.Time, cachedTest []byte) error {
+	defer func() { atomic.AddInt32(&ft.nCachedTraces, 1) }()
+	fmt.Printf("\nCachedTrace()\n")
 	return nil
 }
 
@@ -70,7 +71,7 @@ func (ft *fakeTracer) Traces() int32 {
 }
 
 func (ft *fakeTracer) TracesCached() int32 {
-	return atomic.LoadInt32(&ft.nTraceFromCachedTraces)
+	return atomic.LoadInt32(&ft.nCachedTraces)
 }
 
 type fakeAnnotator struct {
@@ -211,7 +212,11 @@ func newHandler(tracer *fakeTracer) (*Handler, error) {
 		AnnotatorClient: annotator,
 		OutputPath:      "/tmp/annotation1",
 	}
-	return NewHandler(context.TODO(), tracer, ipcCfg, haCfg)
+	newParser, err := parser.New("mda")
+	if err != nil {
+		return nil, err
+	}
+	return NewHandler(context.TODO(), tracer, ipcCfg, newParser, haCfg)
 }
 
 func waitForTrace(t *testing.T, handler *Handler) {


### PR DESCRIPTION
This commit does not change the functionality of traceroute-caller.
It only reorganizes its code so that regular traceroutes can be easily
added in a separate commit.

Changes were tested locally via go test and also docker-compose.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/134)
<!-- Reviewable:end -->
