### PR TITLE
Add NewScamper() to create a new scamper instance

### DIFF
--- a/tracer/scamper.go
+++ b/tracer/scamper.go
@@ -38,7 +38,7 @@ type Scamper struct {
 // NewScamper validates the specified scamper configuration and, if successful,
 // returns a new Scamper instance.  Otherwise, it returns nil and an error.
 func NewScamper(cfg ScamperConfig) (*Scamper, error) {
-	// Validate that the cfg.Binary exists and is executable.
+	// Validate that the cfg.Binary exists and is an executable file.
 	if err := exec.Command("test", "-f", cfg.Binary, "-a", "-x", cfg.Binary).Run(); err != nil {
 		return nil, fmt.Errorf("%q: is not an executable file", cfg.Binary)
 	}
@@ -51,7 +51,7 @@ func NewScamper(cfg ScamperConfig) (*Scamper, error) {
 		return nil, fmt.Errorf("failed to create a directory inside %q (error: %v)", cfg.OutputPath, err)
 	}
 	defer os.RemoveAll(dir)
-	// Validate that timeout is at least one second.
+	// Validate that timeout is at least one second and at most an hour.
 	if cfg.Timeout < 1*time.Second || cfg.Timeout > 3600*time.Second {
 		return nil, fmt.Errorf("%v: invalid timeout value (min: 1s, max 3600s)", cfg.Timeout)
 	}

--- a/tracer/scamper_test.go
+++ b/tracer/scamper_test.go
@@ -20,6 +20,11 @@ func init() {
 }
 
 func TestNewScamper(t *testing.T) {
+	nonWritableDir := "testdata/non-writable"
+	if err := os.MkdirAll(nonWritableDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(nonWritableDir)
 	tests := []struct {
 		binary           string
 		outputPath       string
@@ -33,7 +38,7 @@ func TestNewScamper(t *testing.T) {
 		{"testdata/non-existent", "testdata", 900 * time.Second, "mda", 15, true, "is not an executable file"},
 		{"testdata/non-executable", "testdata", 900 * time.Second, "mda", 15, true, "is not an executable file"},
 		{"/bin/echo", "/dev/null", 900 * time.Second, "mda", 15, true, "failed to create directory"},
-		{"/bin/echo", "/var/empty", 900 * time.Second, "mda", 15, true, "failed to create a directory inside"},
+		{"/bin/echo", nonWritableDir, 900 * time.Second, "mda", 15, true, "failed to create a directory inside"},
 		{"/bin/echo", "testdata", 0, "mda", 15, true, "invalid timeout value (min: 1s, max 3600s)"},
 		{"/bin/echo", "testdata", 3601 * time.Second, "mda", 15, true, "invalid timeout value (min: 1s, max 3600s)"},
 		{"/bin/echo", "testdata", 900 * time.Second, "bad", 15, true, "invalid traceroute type"},

--- a/tracer/scamper_test.go
+++ b/tracer/scamper_test.go
@@ -206,13 +206,13 @@ func TestCachedTrace(t *testing.T) {
 	{"type":"tracelb", "version":"0.1", "userid":0, "method":"icmp-echo", "src":"::ffff:180.87.97.101", "dst":"::ffff:1.47.236.62", "start":{"sec":1566691298, "usec":476221, "ftime":"2019-08-25 00:01:38"}, "probe_size":60, "firsthop":1, "attempts":3, "confidence":95, "tos":0, "gaplimit":3, "wait_timeout":5, "wait_probe":250, "probec":0, "probec_max":3000, "nodec":0, "linkc":0}
 	{"type":"cycle-stop", "list_name":"/tmp/scamperctrl:51811", "id":1, "hostname":"ndt-plh7v", "stop_time":1566691298}`)
 
-	_ = s.CachedTrace("ndt-plh7v_1566050090_000000000004D64D", "1", faketime, []byte("Broken cached traceroute"))
+	_ = s.CachedTrace("1", "ndt-plh7v_1566050090_000000000004D64D", faketime, []byte("Broken cached traceroute"))
 	_, errInvalidTest := ioutil.ReadFile(tempdir + "/2019/04/01/20190401T034551Z_" + prefix.UnsafeString() + "_0000000000000001.jsonl")
 	if errInvalidTest == nil {
 		t.Error("CachedTrace() = nil, want error")
 	}
 
-	_ = s.CachedTrace("ndt-plh7v_1566050090_000000000004D64D", "1", faketime, cachedTrace)
+	_ = s.CachedTrace("1", "ndt-plh7v_1566050090_000000000004D64D", faketime, cachedTrace)
 	// Unmarshal the first line of the output file.
 	b, err := ioutil.ReadFile(tempdir + "/2019/04/01/20190401T034551Z_" + prefix.UnsafeString() + "_0000000000000001.jsonl")
 	rtx.Must(err, "failed to read file")
@@ -293,7 +293,7 @@ func TestInvalidCookie(t *testing.T) {
 	if _, err := s.Trace("10.1.1.1", "an invalid cookie", "", time.Now()); err == nil {
 		t.Error("Trace() = nil, want error")
 	}
-	if err := s.CachedTrace("", "an invalid cookie", time.Now(), nil); err == nil {
+	if err := s.CachedTrace("an invalid cookie", "", time.Now(), nil); err == nil {
 		t.Error("CachedTrace() = nil, want error")
 	}
 }

--- a/triggertrace/triggertrace.go
+++ b/triggertrace/triggertrace.go
@@ -120,7 +120,6 @@ func (h *Handler) Close(ctx context.Context, timestamp time.Time, uuid string) {
 		log.Printf("failed to find destination for UUID %q", uuid)
 		return
 	}
-
 	delete(h.Destinations, uuid)
 	h.DestinationsLock.Unlock()
 	// This goroutine will live for a few minutes and terminate


### PR DESCRIPTION
This commit adds a new function, NewScamper(), to the tracer
package for creating a new instance of scamper based on the
configuration specified in the call if the configuration is valid.
The new scamper instance contains all of the information required
for invoking the scamper binary to run a traceroute.

The changes were tested locally with go test and docker-compose.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/135)
<!-- Reviewable:end -->
