### PR TITLE
Simplify code that executes scamper

### DIFF
--- a/tracer/scamper_test.go
+++ b/tracer/scamper_test.go
@@ -82,8 +82,8 @@ func TestTrace(t *testing.T) {
 		shouldFail bool
 		want       string
 	}{
-		{"testdata/fail", "mda", true, true, "exit status 1: testdata/fail"},
-		{"testdata/loop", "mda", true, true, "signal: killed: testdata/loop"},
+		{"testdata/fail", "mda", true, true, "exit status 1"},
+		{"testdata/loop", "mda", true, true, "signal: killed"},
 
 		{"/bin/echo", "mda", true, false, `{"UUID":"","TracerouteCallerVersion":"` + prometheusx.GitShortCommit + `","CachedTrace":false,"CachedUUID":""}
 -o- -O json -I tracelb -P icmp-echo -q 3 -W 39 -O ptr 10.1.1.1`},


### PR DESCRIPTION
This commit uses the os/exec package to execute an instance of
the scamper command.  Previously, the m-lab/go/shx package was
used because executing the scamper command was more elaborate
and required a 3-stage pipeline.

Changes were tested locally with "go test" and also with
"docker-compose"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/138)
<!-- Reviewable:end -->
