### PR TITLE
Add fast-mda-traceroute to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,9 @@ RUN mkdir -p /var/empty && \
 COPY --from=build_caller /go/bin/traceroute-caller /
 # Copy the dynamically-linked scamper binary and its associated libraries.
 COPY --from=build_tracers /scamper /usr/local
-# Install fast-mda-traceroute from PyPI
-RUN pip3 install --no-cache-dir fast-mda-traceroute==0.1.10
+# Install fast-mda-traceroute from PyPI.
+# We build pycaracal from source to avoid pulling precompiled binaries.
+RUN pip3 install --no-binary pycaracal --no-cache-dir --verbose fast-mda-traceroute==0.1.10
 # Run ldconfig to locate all new libraries and verify the tools we need
 # are available.
 RUN ldconfig && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN chmod +x ./configure && \
 # Create an image for traceroute-caller and the tools that it calls.
 FROM ubuntu:20.04
 RUN apt-get update && \
-    apt-get install -y tini && \
+    apt-get install -y python3-pip tini && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 # Create /var/empty to avoid a race condition in scamper that results
@@ -40,6 +40,8 @@ RUN mkdir -p /var/empty && \
 COPY --from=build_caller /go/bin/traceroute-caller /
 # Copy the dynamically-linked scamper binary and its associated libraries.
 COPY --from=build_tracers /scamper /usr/local
+# Install fast-mda-traceroute from PyPI
+RUN pip3 install --no-cache-dir fast-mda-traceroute==0.1.10
 # Run ldconfig to locate all new libraries and verify the tools we need
 # are available.
 RUN ldconfig && \


### PR DESCRIPTION
This adds [fast-mda-traceroute](https://github.com/dioptra-io/fast-mda-traceroute) to the Docker image so that it can be called by traceroute-caller.
@SaiedKazemi please let me know if this works for you!

This relies on [caracal](https://github.com/dioptra-io/caracal)'s precompiled binaries hosted on PyPI, so it should work out-of-the-box on x86_64 and aarch64 systems.

```bash
docker run --entrypoint fast-mda-traceroute traceroute-caller google.com
# [2022-04-01 16:50:57,106] [INFO] [fast_mda_traceroute] dst_addr=142.250.178.142 interface=eth0 probing_rate=100 buffer_size=1048576 instance_id=15406 integrity_check=True version=0.1.10
# [2022-04-01 16:50:57.107] [info] Resolving the gateway MAC address...
# [2022-04-01 16:50:57.145] [info] dst_mac=02:42:e5:36:74:22
# [2022-04-01 16:50:57.145] [info] src_ip_v4=172.17.0.2 src_ip_v6=::
# [2022-04-01 16:50:57.177] [info] sniffer_filter=(dst 172.17.0.2) and (icmp or icmp6) and (icmp[icmptype] = icmp-echoreply or icmp[icmptype] = icmp-timxceed or icmp[icmptype] = icmp-unreach or icmp6[icmp6type] = icmp6-echoreply or icmp6[icmp6type] = icmp6-timeexceeded or icmp6[icmp6type] = icmp6-destinationunreach)
# [2022-04-01 16:50:57,263] [INFO] [fast_mda_traceroute] round=1 links_found=0 probes=32 expected_time=0.3s
# [2022-04-01 16:50:58,595] [INFO] [fast_mda_traceroute] round=2 links_found=10 probes=50 expected_time=0.5s
# [2022-04-01 16:51:00,100] [INFO] [fast_mda_traceroute] round=3 links_found=10 probes=0 expected_time=0.0s
#   TTL    Src. port    Dst. port  Probe IP         Reply IP         RTT     MPLS label stack
# -----  -----------  -----------  ---------------  ---------------  ------  ------------------
#     1        24000            0  142.250.178.142  172.17.0.1       0.1ms   []
#     1        24004            0  142.250.178.142  172.17.0.1       0.1ms   []
#     1        24005            0  142.250.178.142  172.17.0.1       0.0ms   []
#     1        24002            0  142.250.178.142  172.17.0.1       0.0ms   []
#     1        24003            0  142.250.178.142  172.17.0.1       0.1ms   []
#     1        24001            0  142.250.178.142  172.17.0.1       0.1ms   []
#     ...
#    10        24000            0  142.250.178.142  108.170.244.193  1.3ms   []
#    10        24005            0  142.250.178.142  108.170.244.193  1.3ms   []
#    10        24002            0  142.250.178.142  108.170.244.193  1.5ms   []
#    10        24003            0  142.250.178.142  108.170.244.193  1.3ms   []
#    10        24001            0  142.250.178.142  108.170.244.193  1.2ms   []
#    10        24004            0  142.250.178.142  108.170.244.193  1.2ms   []
#    11        24000            0  142.250.178.142  142.251.64.129   1.2ms   []
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/145)
<!-- Reviewable:end -->
