### PR TITLE
Make MDA traceroutes the default traceroute type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,69 +1,48 @@
-# Build the traceroute-caller binary
-FROM golang:1.16 as build_caller
+# Build the traceroute-caller binary.
+FROM golang:1.18 as build_caller
 ADD . /go/src/github.com/m-lab/traceroute-caller
 RUN rm /go/src/github.com/m-lab/traceroute-caller/Dockerfile
 ENV CGO_ENABLED 0
 ENV GOOS linux
 WORKDIR /go/src/github.com/m-lab/traceroute-caller
-RUN go get -v \
-      -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h)" \
-      .
-RUN chmod -R a+rx /go/bin/traceroute-caller
+RUN go get -v . && \
+    go install -v -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h)" . && \
+    chmod -R a+rx /go/bin/traceroute-caller
 
-
-# Build the binaries that are called by traceroute-caller
+# Build and install the tools that are called by traceroute-caller.
 FROM ubuntu:20.04 as build_tracers
-# Install all the packages we need and then remove the apt-get lists.
-# iproute2 gives us ss
-# all the other packages are for the build processes.
 RUN apt-get update && \
     apt-get install -y make coreutils autoconf libtool git build-essential && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Build and install scamper
-RUN ls -l
+# Build and install scamper.
 RUN mkdir /scamper-src
 ADD ./third_party/scamper/ /scamper-src
 RUN tar xvzf  /scamper-src/scamper-cvs-20211026.tar.gz -C /scamper-src/
-RUN chmod +x /scamper-src/scamper-cvs-20211026/configure
 WORKDIR /scamper-src/scamper-cvs-20211026/
-RUN ./configure --prefix=/scamper
-RUN make -j 8
-RUN make install
+RUN chmod +x ./configure && \
+    ./configure --prefix=/scamper && \
+    make -j 8 &&  \
+    make install
 
-# Create an image for the binaries that are called by traceroute-caller without
-# any of the build tools.
+# Create an image for traceroute-caller and the tools that it calls.
 FROM ubuntu:20.04
-# Install all the packages we need and then remove the apt-get lists.
-# iproute2 gives us ss
 RUN apt-get update && \
-    apt-get install -y iproute2 tini && \
+    apt-get install -y tini && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
 # Create /var/empty to avoid a race condition in scamper that results
 # in the following failure:
 #   scamper_privsep_init: could not mkdir /var/empty: File exists
 RUN mkdir -p /var/empty && \
     chmod 555 /var/empty
-
-# Bring the statically-linked traceroute-caller binary from the go build image.
+# Copy the statically-linked traceroute-caller binary.
 COPY --from=build_caller /go/bin/traceroute-caller /
-
-# Bring the dynamically-linked traceroute binaries and their associated
-# libraries from their build image.
+# Copy the dynamically-linked scamper binary and its associated libraries.
 COPY --from=build_tracers /scamper /usr/local
-
-# They are dynamically-linked, so make sure to run ldconfig to locate all new
-# libraries.
-RUN ldconfig
-
-# Verify that all the binaries we depend on are actually available
-RUN which scamper
-RUN which sc_attach
-RUN which sc_warts2json
-RUN which ss
-
+# Run ldconfig to locate all new libraries and verify the tools we need
+# are available.
+RUN ldconfig && \
+    which scamper tini
 WORKDIR /
 ENTRYPOINT ["tini", "--", "/traceroute-caller"]

--- a/caller.go
+++ b/caller.go
@@ -31,7 +31,7 @@ var (
 	scamperTimeout   = flag.Duration("scamper.timeout", 900*time.Second, "Timeout duration in seconds for scamper to run a traceroute (min 1, max 3600).")
 	scamperTraceType = flagx.Enum{
 		Options: []string{"mda", "regular"},
-		Value:   "regular",
+		Value:   "mda",
 	}
 	scamperTracelbPTR   = flag.Bool("scamper.tracelb-ptr", true, "mda traceroute option: Look up DNS pointer records for IP addresses.")
 	scamperTracelbW     = flag.Int("scamper.tracelb-W", 25, "mda traceroute option: Wait time in 1/100ths of seconds between probes (min 15, max 200).")

--- a/caller_test.go
+++ b/caller_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -29,7 +28,7 @@ func init() {
 
 func TestMain(m *testing.M) {
 	var err error
-	testDir, err = ioutil.TempDir("", "test-directory")
+	testDir, err = os.MkdirTemp("", "test-directory")
 	if err != nil {
 		log.Fatalf("failed to create test directory (error: %v)", err)
 	}

--- a/caller_test.go
+++ b/caller_test.go
@@ -28,6 +28,7 @@ func init() {
 
 func TestMain(m *testing.M) {
 	var err error
+	// testing.M does not have a TempDir() method.
 	testDir, err = os.MkdirTemp("", "test-directory")
 	if err != nil {
 		log.Fatalf("failed to create test directory (error: %v)", err)

--- a/cmd/trex/main.go
+++ b/cmd/trex/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -149,7 +148,7 @@ func parseFile(fileName string) *parser.Scamper1 {
 		nFilesSkipped++
 		return nil
 	}
-	rawData, err := ioutil.ReadFile(fileName)
+	rawData, err := os.ReadFile(fileName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: %v\n", fileName, err)
 		nReadErrors++

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -76,6 +76,8 @@ services:
       - -scamper.tracelb-ptr=true
 
   trc-scamper2:
+    profiles:
+      - donotstart
     build:
       context: .
       dockerfile: Dockerfile

--- a/hopannotation/hopannotation.go
+++ b/hopannotation/hopannotation.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -65,7 +64,7 @@ var (
 
 	// Package testing aid.
 	tickerDuration   = int64(60 * 1000 * time.Millisecond) // ticker duration for cache resetter
-	writeFile        = ioutil.WriteFile
+	writeFile        = os.WriteFile
 	errInvalidConfig = errors.New("invalid context or hop annotation configuration")
 )
 

--- a/internal/triggertrace/triggertrace_test.go
+++ b/internal/triggertrace/triggertrace_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
+	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -49,7 +49,7 @@ func (ft *fakeTracer) Trace(remoteIP, cookie, uuid string, t time.Time) ([]byte,
 	default:
 		jsonl = "./testdata/valid.jsonl"
 	}
-	content, err := ioutil.ReadFile(jsonl)
+	content, err := os.ReadFile(jsonl)
 	if err != nil {
 		return nil, err
 	}

--- a/parser/scamper1_test.go
+++ b/parser/scamper1_test.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -40,7 +40,7 @@ func TestScamper1Parser(t *testing.T) {
 		// Read in the test traceroute output file.
 		f := filepath.Join("./testdata/scamper1", test.file)
 		t.Logf("\nTest %v: file: %v", i, f)
-		content, err := ioutil.ReadFile(f)
+		content, err := os.ReadFile(f)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}

--- a/parser/scamper2_test.go
+++ b/parser/scamper2_test.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -45,7 +45,7 @@ func TestScamper2Parser(t *testing.T) {
 		// Read in the test traceroute output file.
 		f := filepath.Join("./testdata/scamper2", test.file)
 		t.Logf("\nTest %v: file: %v", i, f)
-		content, err := ioutil.ReadFile(f)
+		content, err := os.ReadFile(f)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}

--- a/tracer/scamper.go
+++ b/tracer/scamper.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -45,7 +44,7 @@ func NewScamper(cfg ScamperConfig) (*Scamper, error) {
 	if err := os.MkdirAll(cfg.OutputPath, 0777); err != nil {
 		return nil, fmt.Errorf("failed to create directory %q (error: %v)", cfg.OutputPath, err)
 	}
-	dir, err := ioutil.TempDir(cfg.OutputPath, "trc-testdir")
+	dir, err := os.MkdirTemp(cfg.OutputPath, "trc-testdir")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a directory inside %q (error: %v)", cfg.OutputPath, err)
 	}
@@ -107,7 +106,7 @@ func (s *Scamper) CachedTrace(cookie, uuid string, t time.Time, cachedTrace []by
 	// Create and add the first line to the cached traceroute.
 	newTrace := append(createMetaline(uuid, true, extractUUID(cachedTrace[:split])), cachedTrace[split+1:]...)
 	// Make the file readable so it won't be overwritten.
-	return ioutil.WriteFile(filename, []byte(newTrace), 0444)
+	return os.WriteFile(filename, []byte(newTrace), 0444)
 }
 
 // DontTrace is called when a previous traceroute that we were waiting for
@@ -151,7 +150,7 @@ func traceAndWrite(ctx context.Context, label string, filename string, cmd []str
 	_, _ = buff.Write(createMetaline(uuid, false, ""))
 	_, _ = buff.Write(data)
 	// Make the file readable so it won't be overwritten.
-	return buff.Bytes(), ioutil.WriteFile(filename, buff.Bytes(), 0444)
+	return buff.Bytes(), os.WriteFile(filename, buff.Bytes(), 0444)
 }
 
 // runCmd runs the given command and returns its output.

--- a/tracer/scamper_test.go
+++ b/tracer/scamper_test.go
@@ -3,7 +3,6 @@ package tracer
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -67,7 +66,7 @@ func TestNewScamper(t *testing.T) {
 }
 
 func TestTrace(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestScamper")
+	dir, err := os.MkdirTemp("", "TestScamper")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +120,7 @@ func TestTrace(t *testing.T) {
 			t.Errorf("Trace() = %q, want %q", strings.TrimSpace(got), strings.TrimSpace(test.want))
 		}
 		// Make sure that the output was correctly written to file.
-		out, err = ioutil.ReadFile(path)
+		out, err = os.ReadFile(path)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -133,7 +132,7 @@ func TestTrace(t *testing.T) {
 }
 
 func TestTraceWritesMeta(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "TestTraceWritesUUID")
+	tempdir, err := os.MkdirTemp("", "TestTraceWritesUUID")
 	rtx.Must(err, "failed to create tempdir")
 	defer os.RemoveAll(tempdir)
 
@@ -164,7 +163,7 @@ func TestTraceWritesMeta(t *testing.T) {
 	}
 
 	// Unmarshal the first line of the output file.
-	b, err := ioutil.ReadFile(tempdir + "/2019/04/01/20190401T034551Z_" + prefix.UnsafeString() + "_0000000000000001.jsonl")
+	b, err := os.ReadFile(tempdir + "/2019/04/01/20190401T034551Z_" + prefix.UnsafeString() + "_0000000000000001.jsonl")
 	rtx.Must(err, "failed to read file")
 	m := Metadata{}
 	lines := strings.Split(string(b), "\n")
@@ -182,7 +181,7 @@ func TestTraceWritesMeta(t *testing.T) {
 }
 
 func TestCachedTrace(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "TestCachedTrace")
+	tempdir, err := os.MkdirTemp("", "TestCachedTrace")
 	rtx.Must(err, "failed to create tempdir")
 	defer os.RemoveAll(tempdir)
 
@@ -213,14 +212,14 @@ func TestCachedTrace(t *testing.T) {
 	{"type":"cycle-stop", "list_name":"/tmp/scamperctrl:51811", "id":1, "hostname":"ndt-plh7v", "stop_time":1566691298}`)
 
 	_ = s.CachedTrace("1", "ndt-plh7v_1566050090_000000000004D64D", faketime, []byte("Broken cached traceroute"))
-	_, errInvalidTest := ioutil.ReadFile(tempdir + "/2019/04/01/20190401T034551Z_" + prefix.UnsafeString() + "_0000000000000001.jsonl")
+	_, errInvalidTest := os.ReadFile(tempdir + "/2019/04/01/20190401T034551Z_" + prefix.UnsafeString() + "_0000000000000001.jsonl")
 	if errInvalidTest == nil {
 		t.Error("CachedTrace() = nil, want error")
 	}
 
 	_ = s.CachedTrace("1", "ndt-plh7v_1566050090_000000000004D64D", faketime, cachedTrace)
 	// Unmarshal the first line of the output file.
-	b, err := ioutil.ReadFile(tempdir + "/2019/04/01/20190401T034551Z_" + prefix.UnsafeString() + "_0000000000000001.jsonl")
+	b, err := os.ReadFile(tempdir + "/2019/04/01/20190401T034551Z_" + prefix.UnsafeString() + "_0000000000000001.jsonl")
 	rtx.Must(err, "failed to read file")
 	m := Metadata{}
 	lines := strings.Split(string(b), "\n")

--- a/tracer/scamper_test.go
+++ b/tracer/scamper_test.go
@@ -66,13 +66,10 @@ func TestNewScamper(t *testing.T) {
 }
 
 func TestTrace(t *testing.T) {
-	dir, err := os.MkdirTemp("", "TestScamper")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tempdir := t.TempDir()
 	cookie := "12AB"
 	now := time.Date(2003, 11, 9, 15, 55, 59, 0, time.UTC)
-	path := dir + "/2003/11/09/20031109T155559Z_" + prefix.UnsafeString() + "_00000000000012AB.jsonl"
+	path := tempdir + "/2003/11/09/20031109T155559Z_" + prefix.UnsafeString() + "_00000000000012AB.jsonl"
 
 	tests := []struct {
 		binary     string
@@ -93,7 +90,7 @@ func TestTrace(t *testing.T) {
 		os.RemoveAll(path)
 		scamperCfg := ScamperConfig{
 			Binary:           test.binary,
-			OutputPath:       dir,
+			OutputPath:       tempdir,
 			Timeout:          1 * time.Second,
 			TraceType:        test.traceType,
 			TracelbWaitProbe: 39,
@@ -132,9 +129,7 @@ func TestTrace(t *testing.T) {
 }
 
 func TestTraceWritesMeta(t *testing.T) {
-	tempdir, err := os.MkdirTemp("", "TestTraceWritesUUID")
-	rtx.Must(err, "failed to create tempdir")
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	// Temporarily set the hostname to a value for testing.
 	defer func(oldHn string) {
@@ -181,9 +176,7 @@ func TestTraceWritesMeta(t *testing.T) {
 }
 
 func TestCachedTrace(t *testing.T) {
-	tempdir, err := os.MkdirTemp("", "TestCachedTrace")
-	rtx.Must(err, "failed to create tempdir")
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	// Temporarily set the hostname to a value for testing.
 	defer func(oldHn string) {


### PR DESCRIPTION
This commit does not introduce any functional changes.	Its main
purpose is to make MDA traceroutes the default traceroute
type and run only one traceroute-caller container when using
docker-compose for local development and debugging.  Also,
this commit replaces the deprecated "ioutil" calls with their
equivalents in the "os" package.

Changes were tested locally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/147)
<!-- Reviewable:end -->
