### PR TITLE
Remove the notion of TCP socket cookies

### DIFF
--- a/internal/triggertrace/triggertrace.go
+++ b/internal/triggertrace/triggertrace.go
@@ -88,7 +88,13 @@ func NewHandler(ctx context.Context, tracetool ipcache.Tracer, ipcCfg ipcache.Co
 // Note that this function doesn't use timestamp.
 func (h *Handler) Open(ctx context.Context, timestamp time.Time, uuid string, sockID *inetdiag.SockID) {
 	if sockID == nil {
-		log.Printf("warning: sockID is nil")
+		// TODO(SaiedKazemi): Add a metric here.
+		log.Printf("error: tcp-info passed a nil sockID\n")
+		return
+	}
+	if uuid == "" {
+		// TODO(SaiedKazemi): Add a metric here.
+		log.Printf("error: tcp-info passed an empty uuid for sockID %+v\n", *sockID)
 		return
 	}
 
@@ -100,10 +106,6 @@ func (h *Handler) Open(ctx context.Context, timestamp time.Time, uuid string, so
 	if err != nil {
 		log.Printf("context %p: failed to find destination from SockID %+v\n", ctx, *sockID)
 		return
-	}
-	if uuid == "" {
-		// TODO(SaiedKazemi): Add a metric here.
-		log.Printf("warning: uuid for SockID %+v is empty\n", *sockID)
 	}
 	h.Destinations[uuid] = destination
 }

--- a/internal/triggertrace/triggertrace_test.go
+++ b/internal/triggertrace/triggertrace_test.go
@@ -34,7 +34,7 @@ type fakeTracer struct {
 	nCachedTraces int32
 }
 
-func (ft *fakeTracer) Trace(remoteIP, cookie, uuid string, t time.Time) ([]byte, error) {
+func (ft *fakeTracer) Trace(remoteIP, uuid string, t time.Time) ([]byte, error) {
 	defer func() { atomic.AddInt32(&ft.nTraces, 1) }()
 	var jsonl string
 	switch remoteIP {
@@ -56,7 +56,7 @@ func (ft *fakeTracer) Trace(remoteIP, cookie, uuid string, t time.Time) ([]byte,
 	return content, nil
 }
 
-func (ft *fakeTracer) CachedTrace(cookie, uuid string, t time.Time, cachedTest []byte) error {
+func (ft *fakeTracer) CachedTrace(uuid string, t time.Time, cachedTest []byte) error {
 	defer func() { atomic.AddInt32(&ft.nCachedTraces, 1) }()
 	fmt.Printf("\nCachedTrace()\n")
 	return nil

--- a/tracer/scamper.go
+++ b/tracer/scamper.go
@@ -187,6 +187,9 @@ func runCmd(ctx context.Context, label string, cmd []string) ([]byte, error) {
 
 // generateFilename creates the string filename for storing the data.
 func generateFilename(path, uuid string, t time.Time) (string, error) {
+	if uuid == "" {
+		return "", errors.New("uuid is empty")
+	}
 	dir, err := createDatePath(path, t)
 	if err != nil {
 		// TODO(SaiedKazemi): Add metric here.

--- a/tracer/scamper_test.go
+++ b/tracer/scamper_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/m-lab/go/prometheusx"
 	"github.com/m-lab/go/rtx"
-	"github.com/m-lab/uuid/prefix"
 )
 
 func init() {
@@ -67,10 +66,10 @@ func TestNewScamper(t *testing.T) {
 
 func TestTrace(t *testing.T) {
 	tempdir := t.TempDir()
-	cookie := "12AB"
+	yyyymmdd := "/2003/11/09/20031109T155559Z"
+	uuid := "12AB"
+	filename := tempdir + yyyymmdd + "_" + uuid + ".jsonl"
 	now := time.Date(2003, 11, 9, 15, 55, 59, 0, time.UTC)
-	path := tempdir + "/2003/11/09/20031109T155559Z_" + prefix.UnsafeString() + "_00000000000012AB.jsonl"
-
 	tests := []struct {
 		binary     string
 		traceType  string
@@ -81,13 +80,13 @@ func TestTrace(t *testing.T) {
 		{"testdata/fail", "mda", true, true, "exit status 1"},
 		{"testdata/loop", "mda", true, true, "signal: killed"},
 
-		{"/bin/echo", "mda", true, false, `{"UUID":"","TracerouteCallerVersion":"` + prometheusx.GitShortCommit + `","CachedResult":false,"CachedUUID":""}
+		{"/bin/echo", "mda", true, false, `{"UUID":"` + uuid + `","TracerouteCallerVersion":"` + prometheusx.GitShortCommit + `","CachedResult":false,"CachedUUID":""}
 -o- -O json -I tracelb -P icmp-echo -q 3 -W 39 -O ptr 10.1.1.1`},
-		{"/bin/echo", "mda", false, false, `{"UUID":"","TracerouteCallerVersion":"` + prometheusx.GitShortCommit + `","CachedResult":false,"CachedUUID":""}
+		{"/bin/echo", "mda", false, false, `{"UUID":"` + uuid + `","TracerouteCallerVersion":"` + prometheusx.GitShortCommit + `","CachedResult":false,"CachedUUID":""}
 -o- -O json -I tracelb -P icmp-echo -q 3 -W 39 10.1.1.1`},
 	}
 	for _, test := range tests {
-		os.RemoveAll(path)
+		os.RemoveAll(filename)
 		scamperCfg := ScamperConfig{
 			Binary:           test.binary,
 			OutputPath:       tempdir,
@@ -101,7 +100,7 @@ func TestTrace(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Run a traceroute.
-		out, err := s.Trace("10.1.1.1", cookie, "", now)
+		out, err := s.Trace("10.1.1.1", uuid, now)
 		if test.shouldFail {
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Errorf("Trace() = %q, want %q", err, test.want)
@@ -117,13 +116,13 @@ func TestTrace(t *testing.T) {
 			t.Errorf("Trace() = %q, want %q", strings.TrimSpace(got), strings.TrimSpace(test.want))
 		}
 		// Make sure that the output was correctly written to file.
-		out, err = os.ReadFile(path)
+		out, err = os.ReadFile(filename)
 		if err != nil {
 			t.Fatal(err)
 		}
 		got = string(out)
 		if strings.TrimSpace(got) != strings.TrimSpace(test.want) {
-			t.Errorf("ReadFile(%v) = %q, want %q", path, got, test.want)
+			t.Errorf("ReadFile(%v) = %q, want %q", filename, got, test.want)
 		}
 	}
 }
@@ -152,13 +151,13 @@ func TestTraceWritesMeta(t *testing.T) {
 	faketime := time.Date(2019, time.April, 1, 3, 45, 51, 0, time.UTC)
 	prometheusx.GitShortCommit = "Fake Version"
 	wantUUID := "0123456789"
-	_, err = s.Trace("1.2.3.4", "1", wantUUID, faketime)
+	_, err = s.Trace("1.2.3.4", wantUUID, faketime)
 	if err != nil {
 		t.Errorf("Trace() = %v, want nil", err)
 	}
 
 	// Unmarshal the first line of the output file.
-	b, err := os.ReadFile(tempdir + "/2019/04/01/20190401T034551Z_" + prefix.UnsafeString() + "_0000000000000001.jsonl")
+	b, err := os.ReadFile(tempdir + "/2019/04/01/20190401T034551Z_" + wantUUID + ".jsonl")
 	rtx.Must(err, "failed to read file")
 	m := Metadata{}
 	lines := strings.Split(string(b), "\n")
@@ -199,20 +198,21 @@ func TestCachedTrace(t *testing.T) {
 
 	faketime := time.Date(2019, time.April, 1, 3, 45, 51, 0, time.UTC)
 	prometheusx.GitShortCommit = "Fake Version"
+	uuid := "ndt-plh7v_1566050090_000000000004D64D"
 	cachedTrace := []byte(`{"UUID": "ndt-plh7v_1566050090_000000000004D64D"}
 	{"type":"cycle-start", "list_name":"/tmp/scamperctrl:51811", "id":1, "hostname":"ndt-plh7v", "start_time":1566691298}
 	{"type":"tracelb", "version":"0.1", "userid":0, "method":"icmp-echo", "src":"::ffff:180.87.97.101", "dst":"::ffff:1.47.236.62", "start":{"sec":1566691298, "usec":476221, "ftime":"2019-08-25 00:01:38"}, "probe_size":60, "firsthop":1, "attempts":3, "confidence":95, "tos":0, "gaplimit":3, "wait_timeout":5, "wait_probe":250, "probec":0, "probec_max":3000, "nodec":0, "linkc":0}
 	{"type":"cycle-stop", "list_name":"/tmp/scamperctrl:51811", "id":1, "hostname":"ndt-plh7v", "stop_time":1566691298}`)
 
-	_ = s.CachedTrace("1", "ndt-plh7v_1566050090_000000000004D64D", faketime, []byte("Broken cached traceroute"))
-	_, errInvalidTest := os.ReadFile(tempdir + "/2019/04/01/20190401T034551Z_" + prefix.UnsafeString() + "_0000000000000001.jsonl")
+	_ = s.CachedTrace(uuid, faketime, []byte("Broken cached traceroute"))
+	_, errInvalidTest := os.ReadFile(tempdir + "/2019/04/01/20190401T034551Z_" + uuid + ".jsonl")
 	if errInvalidTest == nil {
 		t.Error("CachedTrace() = nil, want error")
 	}
 
-	_ = s.CachedTrace("1", "ndt-plh7v_1566050090_000000000004D64D", faketime, cachedTrace)
+	_ = s.CachedTrace(uuid, faketime, cachedTrace)
 	// Unmarshal the first line of the output file.
-	b, err := os.ReadFile(tempdir + "/2019/04/01/20190401T034551Z_" + prefix.UnsafeString() + "_0000000000000001.jsonl")
+	b, err := os.ReadFile(tempdir + "/2019/04/01/20190401T034551Z_" + uuid + ".jsonl")
 	rtx.Must(err, "failed to read file")
 	m := Metadata{}
 	lines := strings.Split(string(b), "\n")
@@ -232,9 +232,8 @@ func TestCachedTrace(t *testing.T) {
 	if m.CachedResult != true {
 		t.Errorf("got cached result %v, want true", m.CachedResult)
 	}
-	wantUUID = "ndt-plh7v_1566050090_000000000004D64D"
-	if m.CachedUUID != "ndt-plh7v_1566050090_000000000004D64D" {
-		t.Errorf("got cached UUID %q, want %q", m.CachedUUID, wantUUID)
+	if m.CachedUUID != uuid {
+		t.Errorf("got cached UUID %q, want %q", m.CachedUUID, uuid)
 	}
 }
 
@@ -272,27 +271,6 @@ func TestCreateMetaline(t *testing.T) {
 	wantMeta := []byte("0000000000000ABC\",\"TracerouteCallerVersion\":\"Fake Version\",\"CachedResult\":true,\"CachedUUID\":\"00EF\"")
 	if !bytes.Contains(gotMeta, wantMeta) {
 		t.Errorf("gotMeta %q does not contain wantMeta %q", gotMeta, wantMeta)
-	}
-}
-
-func TestInvalidCookie(t *testing.T) {
-	scamperCfg := ScamperConfig{
-		Binary:           "/bin/echo",
-		OutputPath:       "/tmp",
-		Timeout:          1 * time.Minute,
-		TraceType:        "mda",
-		TracelbPTR:       true,
-		TracelbWaitProbe: 39,
-	}
-	s, err := NewScamper(scamperCfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := s.Trace("10.1.1.1", "an invalid cookie", "", time.Now()); err == nil {
-		t.Error("Trace() = nil, want error")
-	}
-	if err := s.CachedTrace("an invalid cookie", "", time.Now(), nil); err == nil {
-		t.Error("CachedTrace() = nil, want error")
 	}
 }
 

--- a/tracer/scamper_test.go
+++ b/tracer/scamper_test.go
@@ -64,6 +64,30 @@ func TestNewScamper(t *testing.T) {
 	}
 }
 
+func TestEmptyUUID(t *testing.T) {
+	wantErr := "uuid is empty"
+	scamperCfg := ScamperConfig{
+		Binary:           "/bin/false",
+		OutputPath:       t.TempDir(),
+		Timeout:          1 * time.Second,
+		TraceType:        "mda",
+		TracelbWaitProbe: 39,
+		TracelbPTR:       false,
+	}
+	s, err := NewScamper(scamperCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.Trace("1.2.3.4", "", time.Now())
+	if err == nil || !strings.Contains(err.Error(), wantErr) {
+		t.Errorf("Trace() = %v, want %q", err, wantErr)
+	}
+	err = s.CachedTrace("", time.Now(), []byte("does not matter"))
+	if err == nil || !strings.Contains(err.Error(), wantErr) {
+		t.Errorf("Trace() = %v, want %q", err, wantErr)
+	}
+}
+
 func TestTrace(t *testing.T) {
 	tempdir := t.TempDir()
 	yyyymmdd := "/2003/11/09/20031109T155559Z"


### PR DESCRIPTION
The Linux kernel provides a unique cookie for each TCP socket
connection.  The cookie value is used by the tcp-info package to
generate a global UUID that is passed to tcp-info's eventsocket
clients.  Therefore, there is no reason for clients to know
about cookies or generate UUIDs from them.

This commit removes the notion of TCP socket cookies from
traceroute-caller.

Tested the changes locally with docker-compose.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/148)
<!-- Reviewable:end -->
