### PR TITLE
Move trace result writing from tracer package to triggertracer package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,8 @@ COPY --from=build_caller /go/bin/traceroute-caller /
 COPY --from=build_tracers /scamper /usr/local
 # Install fast-mda-traceroute from PyPI.
 # We build pycaracal from source to avoid pulling precompiled binaries.
-RUN pip3 install --no-binary pycaracal --no-cache-dir --verbose fast-mda-traceroute==0.1.10
+# TODO(soltesz): Build failed as of 2022-12-16. Re-enable once needed.
+# RUN pip3 install --no-binary pycaracal --no-cache-dir --verbose fast-mda-traceroute==0.1.10
 # Run ldconfig to locate all new libraries and verify the tools we need
 # are available.
 RUN ldconfig && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,10 +40,12 @@ RUN mkdir -p /var/empty && \
 COPY --from=build_caller /go/bin/traceroute-caller /
 # Copy the dynamically-linked scamper binary and its associated libraries.
 COPY --from=build_tracers /scamper /usr/local
+
 # Install fast-mda-traceroute from PyPI.
 # We build pycaracal from source to avoid pulling precompiled binaries.
-# TODO(soltesz): Build failed as of 2022-12-16. Re-enable once needed.
+# TODO(#152): Build failures as of 2022-12-16. Re-enable once needed.
 # RUN pip3 install --no-binary pycaracal --no-cache-dir --verbose fast-mda-traceroute==0.1.10
+
 # Run ldconfig to locate all new libraries and verify the tools we need
 # are available.
 RUN ldconfig && \

--- a/internal/ipcache/ipcache.go
+++ b/internal/ipcache/ipcache.go
@@ -13,7 +13,7 @@ import (
 // Tracer is the generic interface for all things that can perform a traceroute.
 type Tracer interface {
 	Trace(remoteIP, uuid string, t time.Time) ([]byte, error)
-	CachedTrace(uuid string, t time.Time, cachedTrace []byte) error
+	CachedTrace(uuid string, t time.Time, cachedTrace []byte) ([]byte, error)
 	DontTrace()
 }
 
@@ -98,8 +98,8 @@ func (ic *IPCache) FetchTrace(remoteIP, uuid string) ([]byte, error) {
 			ic.tracetool.DontTrace()
 			return nil, cachedTrace.err
 		}
-		_ = ic.tracetool.CachedTrace(uuid, time.Now(), cachedTrace.data)
-		return cachedTrace.data, nil
+		data, err := ic.tracetool.CachedTrace(uuid, time.Now(), cachedTrace.data)
+		return data, err
 	}
 	cachedTrace.data, cachedTrace.err = ic.tracetool.Trace(remoteIP, uuid, cachedTrace.timeStamp)
 	close(cachedTrace.dataReady)

--- a/internal/ipcache/ipcache_test.go
+++ b/internal/ipcache/ipcache_test.go
@@ -28,9 +28,9 @@ func (ft *fakeTracer) Trace(remoteIP, uuid string, t time.Time) ([]byte, error) 
 	return []byte("fake traceroute data to " + remoteIP), nil
 }
 
-func (ft *fakeTracer) CachedTrace(uuid string, t time.Time, cachedTest []byte) error {
+func (ft *fakeTracer) CachedTrace(uuid string, t time.Time, cachedTest []byte) ([]byte, error) {
 	ft.nCachedTrace++
-	return nil
+	return cachedTest, nil
 }
 
 func (ft *fakeTracer) DontTrace() {
@@ -132,10 +132,10 @@ func (pt *pausingTracer) Trace(remoteIP, uuid string, t time.Time) ([]byte, erro
 	return []byte("fake traceroute data to " + remoteIP), nil
 }
 
-func (pt *pausingTracer) CachedTrace(uuid string, t time.Time, cachedTest []byte) error {
+func (pt *pausingTracer) CachedTrace(uuid string, t time.Time, cachedTest []byte) ([]byte, error) {
 	randomDelay()
 	atomic.AddInt64(&pt.successes, 1)
-	return nil
+	return cachedTest, nil
 }
 
 func (pt *pausingTracer) DontTrace() {

--- a/internal/triggertrace/triggertrace.go
+++ b/internal/triggertrace/triggertrace.go
@@ -63,7 +63,7 @@ type Handler struct {
 	IPCache          FetchTracer
 	Parser           ParseTracer
 	HopAnnotator     AnnotateAndArchiver
-	Scamper          TracerWriter
+	Tracer           TracerWriter
 	done             chan struct{} // For testing.
 }
 
@@ -87,7 +87,7 @@ func NewHandler(ctx context.Context, tracetool TracerWriter, ipcCfg ipcache.Conf
 		IPCache:      ipCache,
 		Parser:       newParser,
 		HopAnnotator: hopCache,
-		Scamper:      tracetool,
+		Tracer:       tracetool,
 	}, nil
 }
 
@@ -153,9 +153,9 @@ func (h *Handler) traceAnnotateAndArchive(ctx context.Context, uuid string, dest
 		return
 	}
 	traceStartTime := parsedData.StartTime()
-	err = h.Scamper.WriteFile(uuid, traceStartTime, rawData)
+	err = h.Tracer.WriteFile(uuid, traceStartTime, rawData)
 	if err != nil {
-		log.Printf("writing scamper trace failed for uuid: %s: %v\n", uuid, err)
+		log.Printf("context %p: failed to write trace file for uuid: %s: (error: %v)\n", ctx, uuid, err)
 	}
 
 	hops := parsedData.ExtractHops()

--- a/internal/triggertrace/triggertrace.go
+++ b/internal/triggertrace/triggertrace.go
@@ -50,7 +50,7 @@ type AnnotateAndArchiver interface {
 	WriteAnnotations(map[string]*annotator.ClientAnnotations, time.Time) []error
 }
 
-type ScamperTracerWriter interface {
+type TracerWriter interface {
 	ipcache.Tracer
 	WriteFile(uuid string, t time.Time, b []byte) error
 }
@@ -63,12 +63,12 @@ type Handler struct {
 	IPCache          FetchTracer
 	Parser           ParseTracer
 	HopAnnotator     AnnotateAndArchiver
-	Scamper          ScamperTracerWriter
+	Scamper          TracerWriter
 	done             chan struct{} // For testing.
 }
 
 // NewHandler returns a new instance of Handler.
-func NewHandler(ctx context.Context, tracetool ScamperTracerWriter, ipcCfg ipcache.Config, newParser parser.TracerouteParser, haCfg hopannotation.Config) (*Handler, error) {
+func NewHandler(ctx context.Context, tracetool TracerWriter, ipcCfg ipcache.Config, newParser parser.TracerouteParser, haCfg hopannotation.Config) (*Handler, error) {
 	ipCache, err := ipcache.New(ctx, tracetool, ipcCfg)
 	if err != nil {
 		return nil, err

--- a/internal/triggertrace/triggertrace_test.go
+++ b/internal/triggertrace/triggertrace_test.go
@@ -56,10 +56,14 @@ func (ft *fakeTracer) Trace(remoteIP, uuid string, t time.Time) ([]byte, error) 
 	return content, nil
 }
 
-func (ft *fakeTracer) CachedTrace(uuid string, t time.Time, cachedTest []byte) error {
+func (ft *fakeTracer) WriteFile(uuid string, t time.Time, data []byte) error {
+	return nil
+}
+
+func (ft *fakeTracer) CachedTrace(uuid string, t time.Time, cachedTest []byte) ([]byte, error) {
 	defer func() { atomic.AddInt32(&ft.nCachedTraces, 1) }()
 	fmt.Printf("\nCachedTrace()\n")
-	return nil
+	return nil, nil
 }
 
 func (ft *fakeTracer) DontTrace() {

--- a/tracer/scamper.go
+++ b/tracer/scamper.go
@@ -14,6 +14,7 @@ import (
 )
 
 var (
+	// ErrEmptyUUID is returned when a required UUID is empty.
 	ErrEmptyUUID = errors.New("uuid is empty")
 )
 
@@ -80,7 +81,7 @@ func NewScamper(cfg ScamperConfig) (*Scamper, error) {
 	}, nil
 }
 
-// WriteFile write the given data to a file in the configured Scamper output
+// WriteFile writes the given data to a file in the configured Scamper output
 // path using the given UUID and time.
 func (s *Scamper) WriteFile(uuid string, t time.Time, data []byte) error {
 	filename, err := generateFilename(s.outputPath, uuid, t)

--- a/tracer/scamper_test.go
+++ b/tracer/scamper_test.go
@@ -186,7 +186,7 @@ func TestTraceWritesMeta(t *testing.T) {
 	}
 	err = s.WriteFile(wantUUID, faketime, out)
 	if err != nil {
-		t.Errorf("WriteFile() error = %v, want nil", err)
+		t.Errorf("WriteFile() = %v, want nil", err)
 	}
 
 	// Unmarshal the first line of the output file.
@@ -244,7 +244,7 @@ func TestCachedTrace(t *testing.T) {
 
 	b, err := s.CachedTrace(uuid, faketime, cachedTrace)
 	if err != nil {
-		t.Errorf("CacheTrace() returned error %v, want nil", err)
+		t.Errorf("CacheTrace() = %v, want nil", err)
 	}
 	// Unmarshal the first line of the output file.
 	m := Metadata{}

--- a/tracer/scamper_test.go
+++ b/tracer/scamper_test.go
@@ -180,20 +180,20 @@ func TestTraceWritesMeta(t *testing.T) {
 	faketime := time.Date(2019, time.April, 1, 3, 45, 51, 0, time.UTC)
 	prometheusx.GitShortCommit = "Fake Version"
 	wantUUID := "0123456789"
-	b, err := s.Trace("1.2.3.4", wantUUID, faketime)
+	out, err := s.Trace("1.2.3.4", wantUUID, faketime)
 	if err != nil {
 		t.Errorf("Trace() = %v, want nil", err)
 	}
-	err = s.WriteFile(wantUUID, faketime, b)
+	err = s.WriteFile(wantUUID, faketime, out)
 	if err != nil {
 		t.Errorf("WriteFile() error = %v, want nil", err)
 	}
 
 	// Unmarshal the first line of the output file.
-	b, err = os.ReadFile(tempdir + "/2019/04/01/20190401T034551Z_" + wantUUID + ".jsonl")
+	out, err = os.ReadFile(tempdir + "/2019/04/01/20190401T034551Z_" + wantUUID + ".jsonl")
 	rtx.Must(err, "failed to read file")
 	m := Metadata{}
-	lines := strings.Split(string(b), "\n")
+	lines := strings.Split(string(out), "\n")
 	if len(lines) < 2 {
 		t.Errorf("len(lines) = %d, want 2", len(lines))
 	}

--- a/tracer/scamper_test.go
+++ b/tracer/scamper_test.go
@@ -67,7 +67,7 @@ func TestNewScamper(t *testing.T) {
 func TestEmptyUUID(t *testing.T) {
 	wantErr := "uuid is empty"
 	scamperCfg := ScamperConfig{
-		Binary:           "/usr/bin/false",
+		Binary:           "/bin/false",
 		OutputPath:       t.TempDir(),
 		Timeout:          1 * time.Second,
 		TraceType:        "mda",


### PR DESCRIPTION
This change is one of two to support anonymizing traceroutes. This change alters the `tracer.Scamper` package interface to separate the collection of traces (by `Trace` and `CachedTrace`) from the writing of traces to a file (by `WriteFile`). This separation allows the `triggertracer` package, which currently writes hop annotations, to be responsible for writing all files, including the trace output.

The second change will anonymize the trace data before writing to file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/151)
<!-- Reviewable:end -->
