### PR TITLE
Fix building issues with fast-mda-traceroute

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN go get -v . && \
     chmod -R a+rx /go/bin/traceroute-caller
 
 # Build and install the tools that are called by traceroute-caller.
-FROM ubuntu:20.04 as build_tracers
+FROM ubuntu:22.04 as build_tracers
 RUN apt-get update && \
     apt-get install -y make coreutils autoconf libtool git build-essential && \
     apt-get clean && \
@@ -26,7 +26,7 @@ RUN chmod +x ./configure && \
     make install
 
 # Create an image for traceroute-caller and the tools that it calls.
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 RUN apt-get update && \
     apt-get install -y python3-pip tini && \
     apt-get clean && \
@@ -43,7 +43,8 @@ COPY --from=build_tracers /scamper /usr/local
 
 # Install fast-mda-traceroute from PyPI.
 # We build pycaracal from source to avoid pulling precompiled binaries.
-RUN pip3 install --no-binary pycaracal --no-cache-dir --verbose fast-mda-traceroute==0.1.10
+RUN pip3 install --upgrade pip wheel setuptools
+RUN pip3 install --no-binary pycaracal --no-cache-dir --verbose fast-mda-traceroute==0.1.13
 
 # Run ldconfig to locate all new libraries and verify the tools we need
 # are available.


### PR DESCRIPTION
Hi,

@SaiedKazemi noticed me that the ci/dockercloud-stage was still failing (see #152) due to the building of fast-mda-traceroute (FMT), and in particular pycaracal dependency. 

Luckily I could reproduce the issue locally this time. 
I think the issue could be resolved by simply updating Python packaging management tools (pip, wheel and setuptool) before installing pycaracal and FMT in the Dockerfile :

```
RUN pip3 install --upgrade pip wheel setuptools
```

Unfortunately, this simple change led to a cascade of other changes in pycaracal (https://github.com/dioptra-io/caracal/pull/53, https://github.com/dioptra-io/caracal/pull/54) and FMT(https://github.com/dioptra-io/fast-mda-traceroute/pull/3) to make it work properly (the principal reason is that now Conan is by default in version 2.0, which lead to breaking changes in pycaracal build) . 

It works now locally but I also had to upgrade the Ubuntu Docker image from 20.04 to 22.04 to have Python 3.10 by default. 
If it's not ok for other reasons, we could also just update the Python version to 3.10 in the 20.04 Ubuntu Docker image. 

If it looks good to you, we could test if the Docker CI works with these changes. 

Best,
Matthieu.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/160)
<!-- Reviewable:end -->
