### PR TITLE
Update m-lab/go to v0.1.66

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/go-test/deep v1.0.7
-	github.com/m-lab/go v0.1.56
+	github.com/m-lab/go v0.1.66
 	github.com/m-lab/tcp-info v1.5.3
 	github.com/m-lab/uuid-annotator v0.4.7
 	github.com/prometheus/client_golang v1.12.2

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/m-lab/annotation-service v0.0.0-20210504151333-138bdf572368 h1:cRzgLEJxoMI0iSexWOxTZQR/gNG08ra1IoEEgwJBdgs=
-github.com/m-lab/go v0.1.56 h1:+E1jnwGChchHT1cOjwomj6xrdQwdPAY8tzfqndddPNU=
-github.com/m-lab/go v0.1.56/go.mod h1:O1D/EoVarJ8lZt9foANcqcKtwxHatBzUxXFFyC87aQQ=
+github.com/m-lab/go v0.1.66 h1:adDJILqKBCkd5YeVhCrrjWkjoNRtDzlDr6uizWu5/pE=
+github.com/m-lab/go v0.1.66/go.mod h1:O1D/EoVarJ8lZt9foANcqcKtwxHatBzUxXFFyC87aQQ=
 github.com/m-lab/tcp-info v1.5.3 h1:4IspTPcNc8D8LNRvuFnID8gDiz+hxPAtYvpKZaiGGe8=
 github.com/m-lab/tcp-info v1.5.3/go.mod h1:bkvI4qbjB6QVC2tsLSHqf5OnIYcmuLEVjo7+8YA56Kg=
 github.com/m-lab/uuid-annotator v0.4.7 h1:DU1X1bac3ihfnUjK8LKTrSfAwiG0cBu1iaEjSwx12pM=


### PR DESCRIPTION
Part of https://github.com/m-lab/dev-tracker/issues/674

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/164)
<!-- Reviewable:end -->
