### PR TITLE
Add load balancer IPs to "localIPs"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- "1.21"
+- "1.20"
 
 before_install:
 - go install github.com/mattn/goveralls@latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.21
+- 1.20
 
 before_install:
 - go install github.com/mattn/goveralls@latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.20
+- 1.21
 
 before_install:
 - go install github.com/mattn/goveralls@latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.20
+- "1.21"
 
 before_install:
 - go install github.com/mattn/goveralls@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/m-lab/traceroute-caller
 
-go 1.20
+go 1.21
 
 require (
 	github.com/go-test/deep v1.0.7

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,7 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-test/deep v1.0.7 h1:/VSMRlnY/JSyqxQUzQLKVMAskpY/NZKFA5j2P+0pP2M=
 github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/gocarina/gocsv v0.0.0-20210408192840-02d7211d929d h1:r3mStZSyjKhEcgbJ5xtv7kT5PZw/tDiFBTMgQx2qsXE=
+github.com/gocarina/gocsv v0.0.0-20210408192840-02d7211d929d/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -224,6 +225,7 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kabukky/httpscerts v0.0.0-20150320125433-617593d7dcb3 h1:Iy7Ifq2ysilWU4QlCx/97OoI4xT1IV7i8byT/EyIT/M=
+github.com/kabukky/httpscerts v0.0.0-20150320125433-617593d7dcb3/go.mod h1:BYpt4ufZiIGv2nXn4gMxnfKV306n3mWXgNu/d2TqdTU=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -232,6 +234,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/m-lab/annotation-service v0.0.0-20210504151333-138bdf572368 h1:cRzgLEJxoMI0iSexWOxTZQR/gNG08ra1IoEEgwJBdgs=
+github.com/m-lab/annotation-service v0.0.0-20210504151333-138bdf572368/go.mod h1:bW5A2AmUqyh6kGbmu4X8fYK2pRcfTvTjAXW/+4VQZUA=
 github.com/m-lab/go v0.1.66 h1:adDJILqKBCkd5YeVhCrrjWkjoNRtDzlDr6uizWu5/pE=
 github.com/m-lab/go v0.1.66/go.mod h1:O1D/EoVarJ8lZt9foANcqcKtwxHatBzUxXFFyC87aQQ=
 github.com/m-lab/tcp-info v1.5.3 h1:4IspTPcNc8D8LNRvuFnID8gDiz+hxPAtYvpKZaiGGe8=
@@ -298,6 +301,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/triggertrace/triggertrace.go
+++ b/internal/triggertrace/triggertrace.go
@@ -118,7 +118,7 @@ func (h *Handler) Open(ctx context.Context, timestamp time.Time, uuid string, so
 	defer h.DestinationsLock.Unlock()
 	destination, err := h.findDestination(sockID)
 	if err != nil {
-		log.Printf("context %p: failed to find destination from SockID %+v\n", ctx, *sockID)
+		log.Printf("context %p: failed to find destination from SockID %+v: %v\n", ctx, *sockID, err)
 		return
 	}
 	h.Destinations[uuid] = destination

--- a/internal/triggertrace/triggertrace.go
+++ b/internal/triggertrace/triggertrace.go
@@ -282,6 +282,7 @@ func loadbalancerIPs(localIPs []*net.IP) ([]*net.IP, error) {
 		}
 		ip := net.ParseIP(string(ipData))
 		localIPs = append(localIPs, &ip)
+		log.Printf("added load balancer IP %s to localIPs\n", ipData)
 	}
 
 	return localIPs, nil

--- a/internal/triggertrace/triggertrace_test.go
+++ b/internal/triggertrace/triggertrace_test.go
@@ -124,6 +124,7 @@ func TestNewHandler(t *testing.T) {
 	os.WriteFile(metadataDir+"/loadbalanced", []byte("true"), 0644)
 	os.WriteFile(metadataDir+"/external-ip", []byte(strV4), 0644)
 	os.WriteFile(metadataDir+"/external-ipv6", []byte(strV6), 0644)
+	defer os.RemoveAll(metadataDir)
 
 	netInterfaceAddrs = fakeInterfaceAddrs
 	handler, err := newHandler(t, &fakeTracer{})
@@ -138,28 +139,28 @@ func TestNewHandler(t *testing.T) {
 
 	ok := false
 	for _, v := range handler.LocalIPs {
-		if v.String() == ipv4.String() {
+		if v.Equal(ipv4) {
 			ok = true
 			break
 		}
 	}
 	if !ok {
-		t.Fatal("NewHandler(): LocalIPs does not contain loadbalancer IP 77.77.88.88")
+		t.Fatalf("NewHandler(): h.LocalIPs does not contain loadbalancer IP %s", strV4)
 	}
 
 	ok = false
 	for _, v := range handler.LocalIPs {
-		if v.String() == ipv6.String() {
+		if v.Equal(ipv6) {
 			ok = true
 			break
 		}
 	}
 	if !ok {
-		t.Fatal("NewHandler(): LocalIPs does not contain loadbalancer IP 7777.77.888.88::")
+		t.Fatalf("NewHandler(): h.LocalIPs does not contain loadbalancer IP %s", strV6)
 	}
 
 	// Setting loadbalanced=false should result in the original addrCount to
-	// stay the same, since no loadbalancer IPs should be added to LocalIPs.
+	// stay the same, since loadbalancerIPs() should return localIPs unmodified.
 	os.WriteFile(metadataDir+"/loadbalanced", []byte("false"), 0644)
 	handler, _ = newHandler(t, &fakeTracer{})
 	if len(handler.LocalIPs) > addrCount {
@@ -167,8 +168,8 @@ func TestNewHandler(t *testing.T) {
 	}
 
 	// If the metadata file loadbalanced doesn't exist then the original
-	// addrCount should stay the same, since no loadbalancer IPs should be added
-	// to LocalIPs.
+	// addrCount should stay the same, since loadbalancerIPs() should return
+	// localIPs unmodified.
 	os.Remove(metadataDir + "/loadbalanced")
 	handler, _ = newHandler(t, &fakeTracer{})
 	if len(handler.LocalIPs) > addrCount {
@@ -419,7 +420,7 @@ func TestAnonymize(t *testing.T) {
 				t.Fatalf("NewHandler() = %v, want nil", err)
 			}
 			l := net.ParseIP(tt.input.Tracelb.Src)
-			h.LocalIPs = []*net.IP{&l}
+			h.LocalIPs = []net.IP{l}
 			h.done = make(chan struct{})
 			sockID := &inetdiag.SockID{SrcIP: tt.input.Tracelb.Src, DstIP: tt.input.Tracelb.Dst}
 			h.Open(context.TODO(), time.Now(), tt.name, sockID)


### PR DESCRIPTION
It was recently discovered that VMs that are part of managed instance groups (i.e., load balanced) are not producing hopannotation2 or scamper1 data from the traceroute-caller container. This is because the socket information provided by tcp-info specifies the load balancer IP address, and traceroute-caller was unable to identify the address as "local", so would refuse to run traces, exiting with an error.

This PR adds a new `loadbalanerIPs()` function which will extract loadbalancer IP addresses, if any, from machine metadata (/var/local/metadata) mounted into the container at /metadata. It adds any loadbalancer IPs to the slice `handler.LocalIPs` so that it can associate LB IP addresses as local, allowing it to determine the proper destination for a traceroute.

I made one other small change, which was to change the type of `Handler.LocalIPs` from `[]*net.IP` to `[]net.IP`. I found the slice-of-pointers hard to work with, and unless there was some reason that was being done that I'm not aware of, it is apparently generally bad form in Go to create slices of pointers, since slices are passed around by reference by default anyway.

I also took the opportunity to update Go to v1.21 (maybe I should have gone to v1.22?)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/traceroute-caller/167)
<!-- Reviewable:end -->
